### PR TITLE
#3 - Refactor controller functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ TODO:
 * Add text explaining the assertion to all of the test assertions
 * Add special User model type with signin, out, password reset, etc
 * Make it optional whether to use Auth or an internal user store
-
-* Split controller code out into a lib.
 * Define a convention for database relationships in the schema ($rel)
 * Potentially use a before/after/each plugin for Tape, or just switch to Mocha
 * Investigate other routing/middleware frameworks. Express, Hapi, Koa, etc.

--- a/controller/controller.mustache
+++ b/controller/controller.mustache
@@ -1,67 +1,8 @@
-const jsen = require('jsen');
 const _ = require('lodash');
-
-const r = require('../lib/db.js');
-const schema = require('../schema.js').{{name}};
-const validate = jsen(schema);
-
-const firstChange = res => {
-  return {
-    result: res.changes[0].new_val || res.changes[0],
-    old_val: res.changes[0].old_val
-  }
-}
-
-const properties = Object.keys(schema.properties);
-
-const onlyProps = params => (p, prop) => {
-  p[prop] = params[prop];
-  return p
-}
-
-const stringToBool = params => {
-  return Object.keys(params).reduce((p, k) => {
-    const param = params[k];
-    switch (param) {
-      case 'true':
-        p[k] = true;
-        break;
-      case 'false':
-        p[k] = false;
-        break;
-      default:
-        p[k] = param;
-    }
-    return p;
-  }, {});
-}
-
-const stringToNumber = params => {
-  return Object.keys(params).reduce((p, k) => {
-    const param = params[k];
-    const num = Number(param);
-    p[k] = param;
-    if (!isNaN(num)) p[k] = num;
-    return p;
-  }, {});
-}
-
-const normaliseParams = params => {
-  return stringToBool(stringToNumber(params));
-}
-
-const buildQuery = (table, params) => {
-  return ['orderBy', 'skip', 'limit'].reduce((q, item) => {
-    if (params[item]) {
-      if (item === 'orderBy') {
-        q = q[item](r[params.order](params[item]));
-      } else {
-        q = q[item](params[item]);
-      }
-    }
-    return q;
-  }, table);
-}
+const r = require('../lib/db');
+const controller = require('../lib/controller');
+const rethinkdb = require('../lib/rethinkdb');
+const schema = require('../lib/schema');
 
 module.exports = {
   get: (params) => {
@@ -72,12 +13,10 @@ module.exports = {
       .then(res => { return {result: res} });
     }
 
-    params = _.assign({result: true, order: 'asc'}, normaliseParams(params));
+    params = _.assign({result: true, order: 'asc'}, controller.normaliseParams(params));
 
-    const filterParams = properties.reduce(onlyProps(params), {});
-    const filteredTable = table.filter(filterParams);
-
-    const query = buildQuery(filteredTable, params);
+    const filteredTable = table.filter(schema.filter('{{name}}', params));
+    const query = rethinkdb.buildQuery(filteredTable, params);
 
     const taggedQueries = [
       {tag: 'result', q: query},
@@ -102,32 +41,30 @@ module.exports = {
       return table.get(params.id).changes({includeInitial: true, includeStates: true}).run();
     }
 
-    params = _.assign({order: 'asc'}, normaliseParams(params));
+    params = _.assign({order: 'asc'}, controller.normaliseParams(params));
 
-    const filterParams = properties.reduce(onlyProps(params), {});
-    const filteredTable = table.filter(filterParams);
-
-    const query = buildQuery(filteredTable, params);
+    const filteredTable = table.filter(schema.filter('{{name}}', params));
+    const query = rethinkdb.buildQuery(filteredTable, params);
 
     return table.getAll(r.args(query.getField('id').coerceTo('array'))).changes({includeInitial: true, includeStates: true}).run();
   },
   create: ({{name}}) => {
-    const valid = validate({{name}});
+    const valid = schema.validate({{name}});
     if (!valid) return Promise.reject(valid);
     return r.table('{{pluralName}}').insert({{name}}, {returnChanges: true}).run()
-    .then(firstChange);
+    .then(rethinkdb.firstChange);
   },
   update: ({{name}}) => {
-    const valid = validate({{name}});
+    const valid = schema.validate({{name}});
     if (!valid) return Promise.reject(valid);
     return r.table('{{pluralName}}').update({{name}}, {returnChanges: true}).run()
-    .then(firstChange);
+    .then(rethinkdb.firstChange);
   },
   delete: (id) => {
     return r.table('{{pluralName}}').get(id).delete({returnChanges: true}).run()
     .then(res => {
       return res;
     })
-    .then(firstChange);
+    .then(rethinkdb.firstChange);
   }
 };

--- a/controller/index.js
+++ b/controller/index.js
@@ -13,19 +13,22 @@ module.exports = (name, pluralName) => {
   console.log('opts are', opts);
 
   const things = [
-    // n: name, p: path, e: extension
-    {n: 'controller', p: 'controllers'},
-    {n: 'test', p: 'tests/controllers'},
-    {n: 'route', p: 'routes'},
-    {n: 'table', p: 'tables'},
-    {n: 'fixture', p: 'fixtures'},
-    {n: 'schema', p: 'schemas', e: 'json'},
-  ].map(thing => _.extend({e: 'js'}, thing));
+    // n: name, p: path, e: extension, t: target filename
+    {n: 'lib/controller'},
+    {n: 'lib/rethinkdb'},
+    {n: 'lib/schema'},
+    {n: 'controller', p: 'controllers', t: name},
+    {n: 'test', p: 'tests/controllers', t: name},
+    {n: 'route', p: 'routes', t: name},
+    {n: 'table', p: 'tables', t: name},
+    {n: 'fixture', p: 'fixtures', t: name},
+    {n: 'schema', p: 'schemas', e: 'json', t: name},
+  ].map(thing => _.extend({p: '', e: 'js', t: thing.n}, thing));
 
   things.forEach(thing => {
     const template = fs.readFileSync(__dirname + '/'+thing.n+'.mustache').toString();
     const dir = path.join(process.cwd(), thing.p);
-    const target = path.join(dir, name+'.'+thing.e);
+    const target = path.join(dir, thing.t+'.'+thing.e);
     console.log('writing', thing.n, 'to', target);
     if (fs.existsSync(target)) return console.error(target, 'already exists. Not overwriting it');
 

--- a/controller/lib/controller.mustache
+++ b/controller/lib/controller.mustache
@@ -1,0 +1,12 @@
+exports.normaliseParams = params => {
+  return Object.keys(params).reduce((p, k) => {
+    const param = params[k];
+
+    p[k] = param;
+    if (!isNaN(Number(param))) p[k] = Number(param);
+    if (param === 'true') p[k] = true;
+    if (param === 'false') p[k] = false;
+
+    return p;
+  }, {});
+}

--- a/controller/lib/rethinkdb.mustache
+++ b/controller/lib/rethinkdb.mustache
@@ -1,12 +1,12 @@
-const r = require('./db.js');
+const r = require('./db');
 
 exports.firstChange = res => {
-  const change = res.changes[0]
+  const change = res.changes[0];
 
   return {
     result: change.new_val || change,
     old_val: change.old_val
-  }
+  };
 }
 
 exports.buildQuery = (table, params) => {

--- a/controller/lib/rethinkdb.mustache
+++ b/controller/lib/rethinkdb.mustache
@@ -1,0 +1,23 @@
+const r = require('./db.js');
+
+exports.firstChange = res => {
+  const change = res.changes[0]
+
+  return {
+    result: change.new_val || change,
+    old_val: change.old_val
+  }
+}
+
+exports.buildQuery = (table, params) => {
+  return ['orderBy', 'skip', 'limit'].reduce((q, item) => {
+    if (params[item]) {
+      if (item === 'orderBy') {
+        q = q[item](r[params.order](params[item]));
+      } else {
+        q = q[item](params[item]);
+      }
+    }
+    return q;
+  }, table);
+}

--- a/controller/lib/schema.mustache
+++ b/controller/lib/schema.mustache
@@ -1,0 +1,11 @@
+const jsen = require('jsen');
+const schema = require('../schema.js');
+
+exports.filter = (name, params) => {
+  return Object.keys(schema[name].properties).reduce((p, prop) => {
+    p[prop] = params[prop]
+    return p
+  }, {})
+}
+
+exports.validate = jsen(schema)

--- a/controller/lib/schema.mustache
+++ b/controller/lib/schema.mustache
@@ -1,11 +1,11 @@
 const jsen = require('jsen');
-const schema = require('../schema.js');
+const schema = require('../schema');
 
 exports.filter = (name, params) => {
   return Object.keys(schema[name].properties).reduce((p, prop) => {
-    p[prop] = params[prop]
-    return p
-  }, {})
+    p[prop] = params[prop];
+    return p;
+  }, {});
 }
 
 exports.validate = jsen(schema)


### PR DESCRIPTION
This branch addresses #3.

The functions existing in `controller.mustache` had various concerns so three separate libs have been created - controller, rethinkdb and schema.

I've also refactored the params normalising to only reduce once.

With the discussion in #2, rethinkdb and schema libs could be repurposed as models, depending which side of the fence that discussion falls on.