### PR TITLE
Migrations

### DIFF
--- a/base/bin/migrate.mustache
+++ b/base/bin/migrate.mustache
@@ -1,0 +1,27 @@
+const migrate = require('root/lib/migrate');
+const r = require('root/lib/db');
+
+const direction = process.argv[2];
+
+const barf = (msg) => {
+  console.log(msg);
+  process.exit(1);
+};
+
+if (!process.argv[2]) {
+  barf('usage: npm run migrate [DIRECTION] [BACKSTOP]');
+};
+
+if (['up', 'down'].indexOf(direction) < 0) {
+  barf('migration direction must be up or down');
+};
+
+if (direction === 'up' && process.argv[3]) {
+  barf('migrate up does not take an argument');
+};
+
+migrate[direction](process.argv[3])
+.then(() => {
+  r.getPoolMaster().drain()
+  .then(() => process.exit());
+});

--- a/base/bin/migration.mustache
+++ b/base/bin/migration.mustache
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const mustache = require('mustache');
+
+const now = new Date().toISOString();
+const migrationName = now + '_' + process.argv[2];
+
+const opts = {migrationName: migrationName};
+
+const migrationTemplate = fs.readFileSync('./bin/migration_template.mustache').toString();
+const migrationTestTemplate = fs.readFileSync('./bin/migration_test_template.mustache').toString();
+
+const migrationFile = mustache.render(migrationTemplate, opts);
+const migrationTest = mustache.render(migrationTestTemplate, opts);
+
+try {
+  fs.mkdirSync('./tests/migrations/');
+} catch(e) {
+  if (e.code !== 'EEXIST') throw e;
+}
+
+fs.writeFileSync('./migrations/' + migrationName + '.js', migrationFile);
+fs.writeFileSync('./tests/migrations/' + migrationName + '.js', migrationTest);

--- a/base/bin/migration_template.mustache
+++ b/base/bin/migration_template.mustache
@@ -1,0 +1,10 @@
+const r = require('root/lib/db');
+
+module.exports = {
+  up: () => {
+    return Promise.resolve();
+  },
+  down: () => {
+    return Promise.resolve();
+  }
+};

--- a/base/bin/migration_test_template.mustache
+++ b/base/bin/migration_test_template.mustache
@@ -1,0 +1,10 @@
+{{=<% %>=}}
+const test = require('blue-tape');
+
+test('{{migrationName}} up should be correct', (t) => {
+  throw new Error('FIXME write a test to ensure the up function works as expected');
+});
+
+test('{{migrationName}} down should be correct', (t) => {
+  throw new Error('FIXME write a test to ensure the down function works as expected');
+});

--- a/base/env/base.mustache
+++ b/base/env/base.mustache
@@ -1,6 +1,10 @@
 module.exports = [
- 'RETHINK_HOST',
- 'RETHINK_PORT',
- 'RETHINK_NAME',
- 'PORT',
+  'RETHINK_HOST',
+  'RETHINK_PORT',
+  'RETHINK_NAME',
+  'PORT',
+  {
+    var: 'AUTOMIGRATE',
+    default: 'true'
+  }
 ];

--- a/base/index.js
+++ b/base/index.js
@@ -30,6 +30,7 @@ module.exports = (name, pluralName) => {
     {n: 'migrations', p: 'tables'},
     {n: 'migrate', p: 'lib'},
     {n: 'migration', p: 'bin'},
+    {n: 'migrate', p: 'bin'},
     {n: 'migration_template', p: 'bin', e: 'mustache'},
     {n: 'migration_test_template', p: 'bin', e: 'mustache'},
   ].map(thing => _.extend({p: '', e: 'js'}, thing));

--- a/base/index.js
+++ b/base/index.js
@@ -27,6 +27,11 @@ module.exports = (name, pluralName) => {
     {n: 'schema'},
     {n: 'schema', p: 'tests/routes'},
     {n: 'schema', p: 'routes'},
+    {n: 'migrations', p: 'tables'},
+    {n: 'migrate', p: 'lib'},
+    {n: 'migration', p: 'bin'},
+    {n: 'migration_template', p: 'bin', e: 'mustache'},
+    {n: 'migration_test_template', p: 'bin', e: 'mustache'},
   ].map(thing => _.extend({p: '', e: 'js'}, thing));
 
   things.forEach(thing => {
@@ -44,7 +49,8 @@ module.exports = (name, pluralName) => {
 
   const dirs = [
     'env',
-    'routes'
+    'routes',
+    'migrations'
   ].forEach(dir => mkdirp.sync(dir));
 
   const modulesDir = path.join(process.cwd(), 'node_modules');

--- a/base/lib/migrate.mustache
+++ b/base/lib/migrate.mustache
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
-const db = require('root/lib/db');
+const r = require('root/lib/db');
 
-const table = db.table('_migrations');
+const table = r.table('_migrations');
 
 const applyMigration = (migrations, then) => {
   if (migrations.length === 0) return;

--- a/base/lib/migrate.mustache
+++ b/base/lib/migrate.mustache
@@ -17,21 +17,27 @@ const applyMigration = (migrations, then) => {
   });
 };
 
+const getMigrationFiles = () => {
+  return fs.readdirSync('./migrations').filter(file => {
+    return file.indexOf('.js') > -1;
+  }).map(file => {
+    return file;
+  });
+};
+
+const getMigrationRecords = () => {
+  return table.run()
+  .then(records => records.map(_.property('name')));
+};
+
 module.exports = {
   up: () => {
-    const migrationFiles = fs.readdirSync('./migrations').filter(file => {
-      return file.indexOf('.js') > -1;
-    }).map(file => {
-      return file;
-    });
+    const migrationFiles = getMigrationFiles();
 
     if (migrationFiles.length < 1) return;
 
-    return table.run()
-    .then(records => {
-      const existingMigrations = records.map(_.property('name'));
-      return _.difference(migrationFiles, existingMigrations);
-    })
+    return getMigrationRecords()
+    .then(existingMigrations => _.difference(migrationFiles, existingMigrations))
     .then(missingMigrations => {
       const toBeApplied = missingMigrations.map(file => {
         return {
@@ -41,8 +47,35 @@ module.exports = {
       });
 
       return applyMigration(toBeApplied, (name) => {
+        console.log('migrated up', name);
         return table.insert({name: name}).run();
       });
     });
+  },
+  down: (backstop) => {
+    const migrationFiles = getMigrationFiles();
+
+    if (migrationFiles.length < 1) return;
+
+    migrationFiles.splice(0, migrationFiles.indexOf(backstop));
+
+    return getMigrationRecords()
+    .then(existingMigrations => _.intersection(migrationFiles, existingMigrations))
+    .then(migrationsToDown => {
+      const toBeDowned = migrationsToDown.reverse()
+      .map(file => {
+        return {
+          func: require('root/migrations/'+file).down,
+          name: file
+        }
+      });
+
+      return applyMigration(toBeDowned, (name) => {
+        console.log('migrated down', name);
+        return table.get(name).delete().run();
+      });
+
+    })
+
   }
 };

--- a/base/lib/migrate.mustache
+++ b/base/lib/migrate.mustache
@@ -8,7 +8,7 @@ const table = r.table('_migrations');
 const applyMigration = (migrations, then) => {
   if (migrations.length === 0) return;
   const m = migrations.shift();
-  m.func()
+  return m.func()
   .then(() => {
     return then(m.name);
   })

--- a/base/lib/migrate.mustache
+++ b/base/lib/migrate.mustache
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const _ = require('lodash');
+const path = require('path');
+const db = require('root/lib/db');
+
+const table = db.table('_migrations');
+
+const applyMigration = (migrations, then) => {
+  if (migrations.length === 0) return;
+  const m = migrations.shift();
+  m.func()
+  .then(() => {
+    return then(m.name);
+  })
+  .then(() => {
+    return applyMigration(migrations, then);
+  });
+};
+
+module.exports = {
+  up: () => {
+    const migrationFiles = fs.readdirSync('./migrations').filter(file => {
+      return file.indexOf('.js') > -1;
+    }).map(file => {
+      return file;
+    });
+
+    if (migrationFiles.length < 1) return;
+
+    return table.run()
+    .then(records => {
+      const existingMigrations = records.map(_.property('name'));
+      return _.difference(migrationFiles, existingMigrations);
+    })
+    .then(missingMigrations => {
+      const toBeApplied = missingMigrations.map(file => {
+        return {
+          func: require('root/migrations/'+file).up,
+          name: file
+        }
+      });
+
+      return applyMigration(toBeApplied, (name) => {
+        return table.insert({name: name}).run();
+      });
+    });
+  }
+};

--- a/base/package.mustache
+++ b/base/package.mustache
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "coverage": "JWT_SECRET=foo RETHINK_HOST=localhost RETHINK_PORT=28015 RETHINK_NAME={{name}} PORT=3001 ./node_modules/.bin/istanbul cover test.js",
+    "migrate": "node ./bin/migrate.js",
     "migration": "node ./bin/migration.js",
     "start": "node start",
     "test": "JWT_SECRET=foo RETHINK_HOST=localhost RETHINK_PORT=28015 RETHINK_NAME={{name}} PORT=3001 node test.js"

--- a/base/package.mustache
+++ b/base/package.mustache
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "coverage": "JWT_SECRET=foo RETHINK_HOST=localhost RETHINK_PORT=28015 RETHINK_NAME={{name}} PORT=3001 ./node_modules/.bin/istanbul cover test.js",
+    "migration": "node ./bin/migration.js",
     "start": "node start",
     "test": "JWT_SECRET=foo RETHINK_HOST=localhost RETHINK_PORT=28015 RETHINK_NAME={{name}} PORT=3001 node test.js"
   },
@@ -24,6 +25,7 @@
     "blue-tape": "^0.1.11",
     "istanbul": "^0.4.1",
     "json-schema-faker": "^0.2.5",
+    "mustache": "^2.2.0",
     "node-fetch": "^1.3.3",
     "rimraf": "^2.4.4",
     "socket.io-client": "^1.3.7"

--- a/base/setup.mustache
+++ b/base/setup.mustache
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const r = require('root/lib/db');
+const migrate = require('root/lib/migrate');
 
 const tables = fs.readdirSync('./tables').map(table => {
   return require(path.resolve('./tables', path.parse(table).name));
@@ -17,4 +18,8 @@ module.exports = () => {
   .then(() => {
     return Promise.all(tables.map(table => table()))
   })
+  .then(() => {
+    if (process.env.AUTOMIGRATE === 'true') return migrate.up();
+    return null;
+  });
 };

--- a/base/tables/migrations.mustache
+++ b/base/tables/migrations.mustache
@@ -1,7 +1,7 @@
 const r = require('../lib/db.js');
 
 module.exports = () => {
-  return r.tableCreate('_migrations').run()
+  return r.tableCreate('_migrations', {primaryKey: 'name'}).run()
   .catch((err) => {
     if (err.message.split('\n')[0] === 'Table `'+process.env.RETHINK_NAME+'._migrations` already exists in:') return;
     throw err;

--- a/base/tables/migrations.mustache
+++ b/base/tables/migrations.mustache
@@ -1,0 +1,12 @@
+const r = require('../lib/db.js');
+
+module.exports = () => {
+  return r.tableCreate('_migrations').run()
+  .catch((err) => {
+    if (err.message.split('\n')[0] === 'Table `'+process.env.RETHINK_NAME+'._migrations` already exists in:') return;
+    throw err;
+  })
+  .then(() => {
+    r.table('_migrations').wait().run()
+  })
+}


### PR DESCRIPTION
This PR adds:

* Scaffolds for writing new migration files with tests
* A util to run migrations both up and down with `npm run migrate`
* An optional (on by default) mechanism to automatically run all upwards migrations when the service is started

Coming in the near future will be the addition of a lock in the database when a process is running migrations. That way you can leave automigrate on and not worry about multiple instances of the app trying to run migrations simultaneously. Submitting this PR before then so that there's less changes to review.