### PR TITLE
Add mutex to migration runners

### DIFF
--- a/base/bin/migrate.mustache
+++ b/base/bin/migrate.mustache
@@ -1,26 +1,50 @@
 const migrate = require('root/lib/migrate');
 const r = require('root/lib/db');
 
-const direction = process.argv[2];
+const commands = [
+  'up',
+  'down',
+  'release_mutex',
+  'show_mutex'
+];
+
+const command = process.argv[2];
 
 const barf = (msg) => {
   console.log(msg);
   process.exit(1);
 };
 
-if (!process.argv[2]) {
+if (!command) {
   barf('usage: npm run migrate [DIRECTION] [BACKSTOP]');
 };
 
-if (['up', 'down'].indexOf(direction) < 0) {
-  barf('migration direction must be up or down');
+if (commands.indexOf(command) < 0) {
+  barf('migration command must be one of: ' + commands.join(' '));
 };
 
-if (direction === 'up' && process.argv[3]) {
+if (command === 'up' && process.argv[3]) {
   barf('migrate up does not take an argument');
 };
 
-migrate[direction](process.argv[3])
+if (command === 'release_mutex' && process.argv[3]) {
+  barf('migrate release_mutex does not take an argument');
+};
+
+if (command === 'release_mutex') {
+  return migrate.releaseMutex()
+  .then(() => r.getPoolMaster().drain())
+  .then(() => process.exit());
+};
+
+if (command === 'show_mutex') {
+  return migrate.queryMutex()
+  .then(console.log)
+  .then(() => r.getPoolMaster().drain())
+  .then(() => process.exit());
+};
+
+migrate[command](process.argv[3])
 .then(() => {
   r.getPoolMaster().drain()
   .then(() => process.exit());

--- a/base/env/base.mustache
+++ b/base/env/base.mustache
@@ -1,10 +1,3 @@
 module.exports = [
-  'RETHINK_HOST',
-  'RETHINK_PORT',
-  'RETHINK_NAME',
-  'PORT',
-  {
-    var: 'AUTOMIGRATE',
-    default: 'true'
-  }
+  'PORT'
 ];

--- a/base/env/db.mustache
+++ b/base/env/db.mustache
@@ -1,0 +1,8 @@
+module.exports = [
+  'RETHINK_HOST',
+  'RETHINK_NAME',
+  {
+    var: 'AUTOMIGRATE',
+    default: 'true'
+  }
+];

--- a/base/index.js
+++ b/base/index.js
@@ -19,6 +19,7 @@ module.exports = (name, pluralName) => {
     {n: 'start'},
     {n: 'test'},
     {n: 'setup'},
+    {n: 'db', p: 'env'},
     {n: 'base', p: 'env'},
     {n: 'package', e: 'json'},
     {n: 'jwt', p: 'tests/middleware'},

--- a/base/lib/migrate.mustache
+++ b/base/lib/migrate.mustache
@@ -1,4 +1,7 @@
+require('required_env')(require('root/env/db'));
+
 const fs = require('fs');
+const os = require('os');
 const _ = require('lodash');
 const path = require('path');
 const r = require('root/lib/db');
@@ -25,6 +28,25 @@ const getMigrationFiles = () => {
   });
 };
 
+const acquireMutex = () => {
+  return r.branch(table.get('migrations_running_mutex'),
+    r.error('mutex locked'),
+    table.insert({
+      hostname: os.hostname(),
+      name: 'migrations_running_mutex',
+      d: new Date().toISOString()
+    })
+  ).run();
+};
+
+const releaseMutex = () => {
+  return table.get('migrations_running_mutex').delete().run();
+};
+
+const queryMutex = () => {
+  return table.get('migrations_running_mutex').run();
+};
+
 const getMigrationRecords = () => {
   return table.run()
   .then(records => records.map(_.property('name')));
@@ -36,7 +58,8 @@ module.exports = {
 
     if (migrationFiles.length < 1) return;
 
-    return getMigrationRecords()
+    return acquireMutex()
+    .then(getMigrationRecords)
     .then(existingMigrations => _.difference(migrationFiles, existingMigrations))
     .then(missingMigrations => {
       const toBeApplied = missingMigrations.map(file => {
@@ -50,7 +73,8 @@ module.exports = {
         console.log('migrated up', name);
         return table.insert({name: name}).run();
       });
-    });
+    })
+    .then(releaseMutex);
   },
   down: (backstop) => {
     const migrationFiles = getMigrationFiles();
@@ -76,6 +100,8 @@ module.exports = {
       });
 
     })
-
-  }
+    .then(releaseMutex);
+  },
+  releaseMutex: releaseMutex,
+  queryMutex: queryMutex
 };


### PR DESCRIPTION
This prevents two instances of the app from attempting to run migrations at the same time.

Also adds helper functions `show_mutex` and `release_mutex` to the migration bin script. These are intended to answer the questions:

1. Why aren't my migrations running?
2. Which machine failed to run my migrations so I can go look at the logs?
3. Okay, I fixed the problem, please remove that mutex so my migrations can run again.

This also splits the env files into `base` and `db` so that the migration runner can demand the db env vars in isolation.