### PR TITLE
Add indexes to schemas

### DIFF
--- a/base/routes/schema.mustache
+++ b/base/routes/schema.mustache
@@ -1,4 +1,4 @@
-const schema = require('root/schema')();
+const schema = require('root/schema').getSchema();
 
 module.exports = {
   http: app => {

--- a/base/routes/schema.mustache
+++ b/base/routes/schema.mustache
@@ -1,4 +1,4 @@
-const schema = require('root/schema');
+const schema = require('root/schema')();
 
 module.exports = {
   http: app => {

--- a/base/schema.mustache
+++ b/base/schema.mustache
@@ -7,4 +7,8 @@ const schema = fs.readdirSync('./schemas').reduce((s, file) => {
   return s;
 }, {});
 
-module.exports = deref(schema);
+const getSchema = () => {
+  return deref(schema);
+}
+
+module.exports = getSchema;

--- a/base/schema.mustache
+++ b/base/schema.mustache
@@ -1,5 +1,9 @@
+const _ = require('lodash');
 const fs = require('fs');
 const deref = require('json-schema-deref-sync');
+const r = require('root/lib/db');
+
+var indexes = {}
 
 const schema = fs.readdirSync('./schemas').reduce((s, file) => {
   const name = file.split('.json')[0];
@@ -7,8 +11,19 @@ const schema = fs.readdirSync('./schemas').reduce((s, file) => {
   return s;
 }, {});
 
-const getSchema = () => {
-  return deref(schema);
+const getIndexes = tableName => {
+  return r.table(tableName).indexList().run()
+    .then(indexes => [tableName, indexes])
 }
 
-module.exports = getSchema;
+exports.setIndexes = () => {
+  return r.tableList().run()
+  .then(tables => _.reject(tables, t => t === '_migrations'))
+  .then(tables => Promise.all(tables.map(getIndexes)))
+  .then(_.zipObject)
+  .then(result => indexes = result);
+}
+
+exports.getSchema = () => {
+  return deref(schema);
+}

--- a/base/schema.mustache
+++ b/base/schema.mustache
@@ -3,7 +3,7 @@ const fs = require('fs');
 const deref = require('json-schema-deref-sync');
 const r = require('root/lib/db');
 
-var indexes = {}
+var indexes = {};
 
 const schema = fs.readdirSync('./schemas').reduce((s, file) => {
   const name = file.split('.json')[0];
@@ -13,8 +13,26 @@ const schema = fs.readdirSync('./schemas').reduce((s, file) => {
 
 const getIndexes = tableName => {
   return r.table(tableName).indexList().run()
-    .then(indexes => [tableName, indexes])
-}
+    .then(indexes => [tableName, indexes]);
+};
+
+// Note: This only adds the .indexed property to the schema's top level
+// properties and not any nested properties that it might have
+const indexModel = (indexes, properties) => {
+  return _.mapValues(properties, (prop, name) => {
+    if (_.includes(indexes, name)) prop.indexed = true;
+    else prop.indexed = false;
+    return prop;
+  });
+};
+
+const transformSchema = (indexes, schema) => {
+  return _.mapValues(schema, (model) => {
+    const modelIndexes = indexes[model.pluralName];
+    model.properties = indexModel(modelIndexes, model.properties);
+    return deref(model);
+  });
+};
 
 exports.setIndexes = () => {
   return r.tableList().run()
@@ -22,8 +40,7 @@ exports.setIndexes = () => {
   .then(tables => Promise.all(tables.map(getIndexes)))
   .then(_.zipObject)
   .then(result => indexes = result);
-}
+};
 
-exports.getSchema = () => {
-  return deref(schema);
-}
+exports.getSchema = () => transformSchema(indexes, schema);
+

--- a/base/setup.mustache
+++ b/base/setup.mustache
@@ -1,12 +1,19 @@
+const _ = require('lodash');
 const fs = require('fs');
 const path = require('path');
 
 const r = require('root/lib/db');
 const migrate = require('root/lib/migrate');
+const schema = require('root/schema');
 
 const tables = fs.readdirSync('./tables').map(table => {
   return require(path.resolve('./tables', path.parse(table).name));
 });
+
+const getIndexes = tableName => {
+  return r.table(tableName).indexList().run()
+    .then(indexes => [tableName, indexes])
+}
 
 module.exports = () => {
   return r.dbCreate(process.env.RETHINK_NAME).run()
@@ -21,5 +28,11 @@ module.exports = () => {
   .then(() => {
     if (process.env.AUTOMIGRATE === 'true') return migrate.up();
     return null;
+  })
+  .then(() => {
+    return r.tableList().run()
+    .then(tables => Promise.all(tables.map(getIndexes)))
+    .then(_.zipObject)
+    .then(indexes => schema.indexes = indexes);
   });
 };

--- a/base/setup.mustache
+++ b/base/setup.mustache
@@ -10,10 +10,6 @@ const tables = fs.readdirSync('./tables').map(table => {
   return require(path.resolve('./tables', path.parse(table).name));
 });
 
-const getIndexes = tableName => {
-  return r.table(tableName).indexList().run()
-    .then(indexes => [tableName, indexes])
-}
 
 module.exports = () => {
   return r.dbCreate(process.env.RETHINK_NAME).run()
@@ -29,10 +25,5 @@ module.exports = () => {
     if (process.env.AUTOMIGRATE === 'true') return migrate.up();
     return null;
   })
-  .then(() => {
-    return r.tableList().run()
-    .then(tables => Promise.all(tables.map(getIndexes)))
-    .then(_.zipObject)
-    .then(indexes => schema.indexes = indexes);
-  });
+  .then(schema.setIndexes);
 };

--- a/base/setup.mustache
+++ b/base/setup.mustache
@@ -10,7 +10,6 @@ const tables = fs.readdirSync('./tables').map(table => {
   return require(path.resolve('./tables', path.parse(table).name));
 });
 
-
 module.exports = () => {
   return r.dbCreate(process.env.RETHINK_NAME).run()
   .catch((err) => {

--- a/base/start.mustache
+++ b/base/start.mustache
@@ -1,9 +1,9 @@
 const setup = require('./setup');
-const app = require('./index');
 
 setup()
 .then(() => {
   const server = app.listen(process.env.PORT, () => {
+    const app = require('./index');
     const host = server.address().address;
     const port = server.address().port;
 

--- a/base/tests/routes/schema.mustache
+++ b/base/tests/routes/schema.mustache
@@ -1,7 +1,7 @@
 const test = require('blue-tape');
 const fetch = require('node-fetch');
 
-const schema = require('root/schema')();
+const schema = require('root/schema').getSchema();
 
 const url = 'http://localhost:'+process.env.PORT+'/schema';
 

--- a/base/tests/routes/schema.mustache
+++ b/base/tests/routes/schema.mustache
@@ -1,7 +1,7 @@
 const test = require('blue-tape');
 const fetch = require('node-fetch');
 
-const schema = require('root/schema');
+const schema = require('root/schema')();
 
 const url = 'http://localhost:'+process.env.PORT+'/schema';
 

--- a/controller/fixture.mustache
+++ b/controller/fixture.mustache
@@ -1,5 +1,5 @@
 const generate = require('json-schema-faker');
-const appSchema = require('../schema.js')();
+const appSchema = require('../schema.js').getSchema();
 const schema = appSchema.{{name}};
 
 module.exports = {

--- a/controller/fixture.mustache
+++ b/controller/fixture.mustache
@@ -1,5 +1,6 @@
 const generate = require('json-schema-faker');
-const schema = require('../schema.js').{{name}};
+const appSchema = require('../schema.js')();
+const schema = appSchema.{{name}};
 
 module.exports = {
   valid: () => {

--- a/controller/lib/schema.mustache
+++ b/controller/lib/schema.mustache
@@ -1,5 +1,5 @@
 const jsen = require('jsen');
-const schema = require('../schema')();
+const schema = require('../schema').getSchema();
 
 exports.filter = (name, params) => {
   return Object.keys(schema[name].properties).reduce((p, prop) => {

--- a/controller/lib/schema.mustache
+++ b/controller/lib/schema.mustache
@@ -1,5 +1,5 @@
 const jsen = require('jsen');
-const schema = require('../schema');
+const schema = require('../schema')();
 
 exports.filter = (name, params) => {
   return Object.keys(schema[name].properties).reduce((p, prop) => {


### PR DESCRIPTION
This PR adds an `.indexed: true/false` property to each of the top level properties (i.e. non nested) that exist within each models schema. This is the stepping stone to then allow us to optimize our queries based on whether the filtered property is or is not indexed.

Because getting indexes is an async operation this happens within the setup step, and the indexed fields are stored internally within the schema.js file. This was the cleanest way I could find.