### PR TITLE
Optimize query

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -13,6 +13,7 @@ module.exports = (opts) => {
     {p: 'bin', n: 'migration_template', e: 'mustache'},
     {p: 'bin', n: 'migration_test_template', e: 'mustache'},
     {p: 'env', n: 'base'},
+    {p: 'env', n: 'db'},
     {p: 'lib', n: 'db'},
     {p: 'lib', n: 'migrate'},
     {n: 'index'},

--- a/base/index.js
+++ b/base/index.js
@@ -6,35 +6,36 @@ const _ = require('lodash');
 
 module.exports = (opts) => {
   const things = [
-    // n: name, p: path, e: extension
-    {n: 'db', p: 'lib'},
+    // p: source path, n: filename
+    // d: destination path, t: target filename, e: target extension
+    {p: 'bin', n: 'migration'},
+    {p: 'bin', n: 'migrate'},
+    {p: 'bin', n: 'migration_template', e: 'mustache'},
+    {p: 'bin', n: 'migration_test_template', e: 'mustache'},
+    {p: 'env', n: 'base'},
+    {p: 'lib', n: 'db'},
+    {p: 'lib', n: 'migrate'},
     {n: 'index'},
+    {n: 'package', e: 'json'},
+    {n: 'schema'},
+    {n: 'setup'},
     {n: 'start'},
     {n: 'test'},
-    {n: 'setup'},
-    {n: 'db', p: 'env'},
-    {n: 'base', p: 'env'},
-    {n: 'package', e: 'json'},
-    {n: 'jwt', p: 'tests/middleware'},
-    {n: 'jwt', p: 'middleware'},
-    {n: 'cors', p: 'middleware'},
-    {n: 'schema'},
-    {n: 'schema', p: 'tests/routes'},
-    {n: 'schema', p: 'routes'},
-    {n: 'migrations', p: 'tables'},
-    {n: 'migrate', p: 'lib'},
-    {n: 'migration', p: 'bin'},
-    {n: 'migrate', p: 'bin'},
-    {n: 'migration_template', p: 'bin', e: 'mustache'},
-    {n: 'migration_test_template', p: 'bin', e: 'mustache'},
-  ].map(thing => _.extend({p: '', e: 'js'}, thing));
+    {p: 'middleware', n: 'jwt'},
+    {p: 'middleware', n: 'cors'},
+    {p: 'routes', n: 'schema'},
+    {p: 'tables', n: 'migrations'},
+    {p: 'tests/middleware', n: 'jwt'},
+    {p: 'tests/routes', n: 'schema'},
+  ].map(thing => _.extend({p: '', d: thing.p || '', t: thing.n, e: 'js'}, thing));
 
   things.forEach(thing => {
     const templatePath = path.join(__dirname, thing.p, thing.n+'.mustache');
     const template = fs.readFileSync(templatePath).toString();
-    const dir = path.join(process.cwd(), thing.p);
-    const target = path.join(dir, thing.n+'.'+thing.e);
-    console.log('writing', thing.n, 'to', target);
+
+    const dir = path.join(process.cwd(), thing.d);
+    const target = path.join(dir, thing.t+'.'+thing.e);
+
     if (fs.existsSync(target)) return console.error(target, 'already exists. Not overwriting it');
 
     mkdirp.sync(dir);

--- a/base/schema.mustache
+++ b/base/schema.mustache
@@ -13,7 +13,7 @@ const schema = fs.readdirSync('./schemas').reduce((s, file) => {
 
 const getIndexes = tableName => {
   return r.table(tableName).indexList().run()
-    .then(indexes => [tableName, indexes]);
+    .then(indexes => [tableName, indexes.concat("id")]);
 };
 
 // Note: This only adds the .indexed property to the schema's top level

--- a/controller/controller.mustache
+++ b/controller/controller.mustache
@@ -7,39 +7,12 @@ const schema = require('../lib/schema');
 const appSchema = require('../schema').getSchema();
 const modelSchema = appSchema['{{name}}'];
 
-// TODO - filter using schema properties?
-const NOT_FILTERS = ['count', 'result', 'order', 'orderBy', 'skip', 'limit'];
-
-const buildQuery = (table, params) => {
-  params = _.omit(params, NOT_FILTERS);
-
-  //if only id passed, run query using .get(x)
-  if (params.id && Object.keys(params).length === 1)
-    return table.get(params.id)
-
-  // NOTE: this only utilises the first indexed field that is found, the
-  // remainder are simply passed to filter
-  const fields = Object.keys(params);
-  const indexedField = fields.filter(f => {
-    const match = modelSchema.properties[f] || {}
-    return match.indexed;
-  })[0]
-
-  if (indexedField != null) {
-    table = table.getAll(params[indexedField], {index: indexedField})
-    delete params[indexedField]
-  }
-  
-  if (!_.isEmpty(params)) table = table.filter(params)
-  return table
-}
-
 module.exports = {
   get: (params) => {
     params = _.assign({result: true}, controller.normaliseParams(params));
  
     const table = r.table('{{pluralName}}');
-    const query = buildQuery(table, params);
+    const query = rethinkdb.buildQuery(modelSchema, table, params);
     const resultsQuery = rethinkdb.addTransformations(query, params)
 
     const taggedQueries = [

--- a/controller/controller.mustache
+++ b/controller/controller.mustache
@@ -11,8 +11,8 @@ module.exports = {
   get: (params) => {
     params = _.assign({result: true}, controller.normaliseParams(params));
 
-    const indexBy = controller.getIndex(modelSchema, params);
     const table = r.table('{{pluralName}}');
+    const indexBy = controller.getIndex(modelSchema, params);
 
     const query = rethinkdb.buildQuery(table, indexBy, params);
     const resultsQuery = rethinkdb.addTransformations(query, params);

--- a/controller/controller.mustache
+++ b/controller/controller.mustache
@@ -10,10 +10,12 @@ const modelSchema = appSchema['{{name}}'];
 module.exports = {
   get: (params) => {
     params = _.assign({result: true}, controller.normaliseParams(params));
- 
+
+    const indexBy = controller.getIndex(modelSchema, params);
     const table = r.table('{{pluralName}}');
-    const query = rethinkdb.buildQuery(modelSchema, table, params);
-    const resultsQuery = rethinkdb.addTransformations(query, params)
+
+    const query = rethinkdb.buildQuery(table, indexBy, params);
+    const resultsQuery = rethinkdb.addTransformations(query, params);
 
     const taggedQueries = [
       {tag: 'result', q: resultsQuery},

--- a/controller/controller.mustache
+++ b/controller/controller.mustache
@@ -10,6 +10,9 @@ const modelSchema = appSchema['{{name}}'];
 var NOT_INDEXED = 'WARNING: query is not using an indexed field, changefeed';
 NOT_INDEXED += ' will not include new documents';
 
+var SORT_LIMIT = 'WARNING: queries using skip and/or limit will not received';
+SORT_LIMIT = 'new documents in the changefeed';
+
 module.exports = {
   get: (params) => {
     params = _.assign({result: true}, controller.normaliseParams(params));
@@ -48,8 +51,14 @@ module.exports = {
     var query = rethinkdb.buildQuery(table, indexBy, queryParams);
     query = rethinkdb.addTransformations(query, params);
  
+    //if query params were passed but none were on an index field
     if (!_.isEmpty(queryParams) && indexBy == null) {
       console.log(NOT_INDEXED);
+      query = table.getAll(r.args(query.getField('id').coerceTo('array')));
+    }
+
+    if (params.limit || params.skip) {
+      console.log(SORT_LIMIT);
       query = table.getAll(r.args(query.getField('id').coerceTo('array')));
     }
 

--- a/controller/controller.mustache
+++ b/controller/controller.mustache
@@ -7,18 +7,22 @@ const schema = require('../lib/schema');
 const appSchema = require('../schema').getSchema();
 const modelSchema = appSchema['{{name}}'];
 
+var NOT_INDEXED = 'WARNING: query is not using an indexed field, changefeed';
+NOT_INDEXED += ' will not include new documents';
+
 module.exports = {
   get: (params) => {
     params = _.assign({result: true}, controller.normaliseParams(params));
+    const queryParams = schema.filter('{{name}}', params);
 
     const table = r.table('{{pluralName}}');
-    const indexBy = controller.getIndex(modelSchema, params);
+    const indexBy = controller.getIndex(modelSchema, queryParams);
 
-    const query = rethinkdb.buildQuery(table, indexBy, params);
-    const resultsQuery = rethinkdb.addTransformations(query, params);
+    const query = rethinkdb.buildQuery(table, indexBy, queryParams);
+    const tranformedQuery = rethinkdb.addTransformations(query, params);
 
     const taggedQueries = [
-      {tag: 'result', q: resultsQuery},
+      {tag: 'result', q: tranformedQuery},
       {tag: 'count', q: query.count()}
     ].filter(x => params[x.tag]);
 
@@ -34,18 +38,22 @@ module.exports = {
     });
   },
   watch: (params) => {
-    const table = r.table('{{pluralName}}');
+    params = controller.normaliseParams(params);
+    const queryParams = schema.filter('{{name}}', params);
 
-    if (params.id) {
-      return table.get(params.id).changes({includeInitial: true, includeStates: true}).run();
+    const changes = {includeInitial: true, includeStates: true};
+    const table = r.table('{{pluralName}}');
+    const indexBy = controller.getIndex(modelSchema, queryParams);
+
+    var query = rethinkdb.buildQuery(table, indexBy, queryParams);
+    query = rethinkdb.addTransformations(query, params);
+ 
+    if (!_.isEmpty(queryParams) && indexBy == null) {
+      console.log(NOT_INDEXED);
+      query = table.getAll(r.args(query.getField('id').coerceTo('array')));
     }
 
-    params = _.assign({order: 'asc'}, controller.normaliseParams(params));
-
-    const filteredTable = table.filter(schema.filter('{{name}}', params));
-    const query = rethinkdb.addTransformations(filteredTable, params);
-
-    return table.getAll(r.args(query.getField('id').coerceTo('array'))).changes({includeInitial: true, includeStates: true}).run();
+    return query.changes(changes).run();
   },
   create: ({{name}}) => {
     const valid = schema.validate({{name}});

--- a/controller/controller.mustache
+++ b/controller/controller.mustache
@@ -4,23 +4,47 @@ const controller = require('../lib/controller');
 const rethinkdb = require('../lib/rethinkdb');
 const schema = require('../lib/schema');
 
+const appSchema = require('../schema').getSchema();
+const modelSchema = appSchema['{{name}}'];
+
+// TODO - filter using schema properties?
+const NOT_FILTERS = ['count', 'result', 'order', 'orderBy', 'skip', 'limit'];
+
+const buildQuery = (table, params) => {
+  params = _.omit(params, NOT_FILTERS);
+
+  //if only id passed, run query using .get(x)
+  if (params.id && Object.keys(params).length === 1)
+    return table.get(params.id)
+
+  // NOTE: this only utilises the first indexed field that is found, the
+  // remainder are simply passed to filter
+  const fields = Object.keys(params);
+  const indexedField = fields.filter(f => {
+    const match = modelSchema.properties[f] || {}
+    return match.indexed;
+  })[0]
+
+  if (indexedField != null) {
+    table = table.getAll(params[indexedField], {index: indexedField})
+    delete params[indexedField]
+  }
+  
+  if (!_.isEmpty(params)) table = table.filter(params)
+  return table
+}
+
 module.exports = {
   get: (params) => {
+    params = _.assign({result: true}, controller.normaliseParams(params));
+ 
     const table = r.table('{{pluralName}}');
-
-    if (params.id) {
-      return table.get(params.id).run()
-      .then(res => { return {result: res} });
-    }
-
-    params = _.assign({result: true, order: 'asc'}, controller.normaliseParams(params));
-
-    const filteredTable = table.filter(schema.filter('{{name}}', params));
-    const query = rethinkdb.buildQuery(filteredTable, params);
+    const query = buildQuery(table, params);
+    const resultsQuery = rethinkdb.addTransformations(query, params)
 
     const taggedQueries = [
-      {tag: 'result', q: query},
-      {tag: 'count', q: filteredTable.count()}
+      {tag: 'result', q: resultsQuery},
+      {tag: 'count', q: query.count()}
     ].filter(x => params[x.tag]);
 
     return Promise.all(taggedQueries.map(x => x.q.run()))
@@ -44,7 +68,7 @@ module.exports = {
     params = _.assign({order: 'asc'}, controller.normaliseParams(params));
 
     const filteredTable = table.filter(schema.filter('{{name}}', params));
-    const query = rethinkdb.buildQuery(filteredTable, params);
+    const query = rethinkdb.addTransformations(filteredTable, params);
 
     return table.getAll(r.args(query.getField('id').coerceTo('array'))).changes({includeInitial: true, includeStates: true}).run();
   },

--- a/controller/index.js
+++ b/controller/index.js
@@ -11,6 +11,7 @@ module.exports = (opts) => {
     {p: 'lib', n: 'controller'},
     {p: 'lib', n: 'rethinkdb'},
     {p: 'lib', n: 'schema'},
+    {p: 'tests/lib', n: 'rethinkdb'},
     {n: 'controller', d: 'controllers', t: opts.name},
     {n: 'test', d: 'tests/controllers', t: opts.name},
     {n: 'route', d: 'routes', t: opts.name},

--- a/controller/index.js
+++ b/controller/index.js
@@ -6,23 +6,26 @@ const _ = require('lodash');
 
 module.exports = (opts) => {
   const things = [
-    // n: name, p: path, e: extension, t: target filename
-    {n: 'lib/controller'},
-    {n: 'lib/rethinkdb'},
-    {n: 'lib/schema'},
-    {n: 'controller', p: 'controllers', t: opts.name},
-    {n: 'test', p: 'tests/controllers', t: opts.name},
-    {n: 'route', p: 'routes', t: opts.name},
-    {n: 'table', p: 'tables', t: opts.name},
-    {n: 'fixture', p: 'fixtures', t: opts.name},
-    {n: 'schema', p: 'schemas', e: 'json', t: opts.name},
-  ].map(thing => _.extend({p: '', e: 'js', t: thing.n}, thing));
+    // p: source path, n: filename
+    // d: destination path, t: target filename, e: target extension
+    {p: 'lib', n: 'controller'},
+    {p: 'lib', n: 'rethinkdb'},
+    {p: 'lib', n: 'schema'},
+    {n: 'controller', d: 'controllers', t: opts.name},
+    {n: 'test', d: 'tests/controllers', t: opts.name},
+    {n: 'route', d: 'routes', t: opts.name},
+    {n: 'table', d: 'tables', t: opts.name},
+    {n: 'fixture', d: 'fixtures', t: opts.name},
+    {n: 'schema', d: 'schemas', t: opts.name, e: 'json'},
+  ].map(thing => _.extend({p: '', d: thing.p, t: thing.n, e: 'js'}, thing));
 
   things.forEach(thing => {
-    const template = fs.readFileSync(__dirname + '/'+thing.n+'.mustache').toString();
-    const dir = path.join(process.cwd(), thing.p);
+    const templatePath = path.join(__dirname, thing.p, thing.n+'.mustache');
+    const template = fs.readFileSync(templatePath).toString();
+
+    const dir = path.join(process.cwd(), thing.d);
     const target = path.join(dir, thing.t+'.'+thing.e);
-    console.log('writing', thing.n, 'to', target);
+
     if (fs.existsSync(target)) return console.error(target, 'already exists. Not overwriting it');
 
     mkdirp.sync(dir);

--- a/controller/index.js
+++ b/controller/index.js
@@ -11,6 +11,7 @@ module.exports = (opts) => {
     {p: 'lib', n: 'controller'},
     {p: 'lib', n: 'rethinkdb'},
     {p: 'lib', n: 'schema'},
+    {p: 'tests/lib', n: 'controller'},
     {p: 'tests/lib', n: 'rethinkdb'},
     {n: 'controller', d: 'controllers', t: opts.name},
     {n: 'test', d: 'tests/controllers', t: opts.name},

--- a/controller/index.js
+++ b/controller/index.js
@@ -19,7 +19,7 @@ module.exports = (opts) => {
     {n: 'table', d: 'tables', t: opts.name},
     {n: 'fixture', d: 'fixtures', t: opts.name},
     {n: 'schema', d: 'schemas', t: opts.name, e: 'json'},
-  ].map(thing => _.extend({p: '', d: thing.p, t: thing.n, e: 'js'}, thing));
+  ].map(thing => _.extend({p: '', d: thing.p || '', t: thing.n, e: 'js'}, thing));
 
   things.forEach(thing => {
     const templatePath = path.join(__dirname, thing.p, thing.n+'.mustache');

--- a/controller/lib/controller.mustache
+++ b/controller/lib/controller.mustache
@@ -19,10 +19,5 @@ exports.getIndex = (schema, params) => {
   if (params.id && fields['id'] && fields['id'].indexed) return 'id';
 
   const properties = schema.properties;
-  for (var key in params) {
-    if (params.hasOwnProperty(key)) { 
-      if (properties[key] && properties[key].indexed) return key;
-    }
-  }
-  return null;
+  return _.findKey(params, (val, key) => properties[key] && properties[key].indexed)
 }

--- a/controller/lib/controller.mustache
+++ b/controller/lib/controller.mustache
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 exports.normaliseParams = params => {
   return Object.keys(params).reduce((p, k) => {
     const param = params[k];
@@ -9,4 +11,18 @@ exports.normaliseParams = params => {
 
     return p;
   }, {});
+}
+
+// return the first query param found that is indexed (id takes precedence)
+exports.getIndex = (schema, params) => {
+  if (params.id) return "id";
+  const fields = Object.keys(params);
+
+  const properties = schema.properties;
+  for (var key in params) {
+    if (params.hasOwnProperty(key)) { 
+      if (properties[key] && properties[key].indexed) return key;
+    }
+  }
+  return null;
 }

--- a/controller/lib/controller.mustache
+++ b/controller/lib/controller.mustache
@@ -15,8 +15,8 @@ exports.normaliseParams = params => {
 
 // return the first query param found that is indexed (id takes precedence)
 exports.getIndex = (schema, params) => {
-  if (params.id) return "id";
   const fields = Object.keys(params);
+  if (params.id && fields['id'] && fields['id'].indexed) return 'id';
 
   const properties = schema.properties;
   for (var key in params) {

--- a/controller/lib/rethinkdb.mustache
+++ b/controller/lib/rethinkdb.mustache
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const r = require('./db');
 
 exports.firstChange = res => {
@@ -22,4 +23,31 @@ exports.addTransformations = (table, params) => {
     }
     return q;
   }, table);
+}
+
+// TODO - filter using schema properties?
+const NOT_FILTERS = ['count', 'result', 'order', 'orderBy', 'skip', 'limit'];
+
+exports.buildQuery = (schema, table, params) => {
+  params = _.omit(params, NOT_FILTERS);
+
+  //if only id passed, run query using .get(x)
+  if (params.id && Object.keys(params).length === 1)
+    return table.get(params.id)
+
+  // NOTE: this only utilises the first indexed field that is found, the
+  // remainder are simply passed to filter
+  const fields = Object.keys(params);
+  const indexedField = fields.filter(f => {
+    const match = schema.properties[f] || {}
+    return match.indexed;
+  })[0]
+
+  if (indexedField != null) {
+    table = table.getAll(params[indexedField], {index: indexedField})
+    delete params[indexedField]
+  }
+  
+  if (!_.isEmpty(params)) table = table.filter(params)
+  return table
 }

--- a/controller/lib/rethinkdb.mustache
+++ b/controller/lib/rethinkdb.mustache
@@ -25,7 +25,8 @@ exports.addTransformations = (table, params) => {
   }, table);
 }
 
-// TODO - filter using schema properties?
+// TODO - filter using schema properties? and throw error if non-existent field
+// is passed via query
 const NOT_FILTERS = ['count', 'result', 'order', 'orderBy', 'skip', 'limit'];
 
 exports.buildQuery = (table, indexBy, params) => {

--- a/controller/lib/rethinkdb.mustache
+++ b/controller/lib/rethinkdb.mustache
@@ -9,11 +9,13 @@ exports.firstChange = res => {
   };
 }
 
-exports.buildQuery = (table, params) => {
+exports.addTransformations = (table, params) => {
   return ['orderBy', 'skip', 'limit'].reduce((q, item) => {
     if (params[item]) {
+      //TODO - this does not use an index if there is one
       if (item === 'orderBy') {
-        q = q[item](r[params.order](params[item]));
+        const order = params.order || 'asc'
+        q = q[item](r[order](params[item]));
       } else {
         q = q[item](params[item]);
       }

--- a/controller/lib/rethinkdb.mustache
+++ b/controller/lib/rethinkdb.mustache
@@ -28,26 +28,17 @@ exports.addTransformations = (table, params) => {
 // TODO - filter using schema properties?
 const NOT_FILTERS = ['count', 'result', 'order', 'orderBy', 'skip', 'limit'];
 
-exports.buildQuery = (schema, table, params) => {
+exports.buildQuery = (table, indexBy, params) => {
   params = _.omit(params, NOT_FILTERS);
 
   //if only id passed, run query using .get(x)
-  if (params.id && Object.keys(params).length === 1)
-    return table.get(params.id)
+  if (params.id && Object.keys(params).length === 1) return table.get(params.id);
 
-  // NOTE: this only utilises the first indexed field that is found, the
-  // remainder are simply passed to filter
-  const fields = Object.keys(params);
-  const indexedField = fields.filter(f => {
-    const match = schema.properties[f] || {}
-    return match.indexed;
-  })[0]
-
-  if (indexedField != null) {
-    table = table.getAll(params[indexedField], {index: indexedField})
-    delete params[indexedField]
+  if (indexBy != null) {
+    table = table.getAll(params[indexBy], {index: indexBy})
+    delete params[indexBy]
   }
   
-  if (!_.isEmpty(params)) table = table.filter(params)
-  return table
+  if (!_.isEmpty(params)) table = table.filter(params);
+  return table;
 }

--- a/controller/lib/rethinkdb.mustache
+++ b/controller/lib/rethinkdb.mustache
@@ -25,13 +25,7 @@ exports.addTransformations = (table, params) => {
   }, table);
 }
 
-// TODO - filter using schema properties? and throw error if non-existent field
-// is passed via query
-const NOT_FILTERS = ['count', 'result', 'order', 'orderBy', 'skip', 'limit'];
-
 exports.buildQuery = (table, indexBy, params) => {
-  params = _.omit(params, NOT_FILTERS);
-
   //if only id passed, run query using .get(x)
   if (params.id && Object.keys(params).length === 1) return table.get(params.id);
 

--- a/controller/lib/schema.mustache
+++ b/controller/lib/schema.mustache
@@ -1,11 +1,14 @@
+const _ = require('lodash');
 const jsen = require('jsen');
 const schema = require('../schema').getSchema();
 
+// filter out params that do not exist as properties on the schema
 exports.filter = (name, params) => {
-  return Object.keys(schema[name].properties).reduce((p, prop) => {
-    p[prop] = params[prop];
-    return p;
-  }, {});
+  const properties = schema[name].properties;
+  return _.reduce(params, (result, value, key) => {
+    if (properties[key]) result[key] = value;
+    return result
+  }, {})
 }
 
 exports.validate = jsen(schema)

--- a/controller/test.mustache
+++ b/controller/test.mustache
@@ -373,59 +373,6 @@ test('websockets should skip if asked', (t) => {
     });
   });
 });
-
-test('websockets should orderBy asc if asked', (t) => {
-  // The websocket API won't return its results in order, but they will be pulled from the right part of the database
-  return {{name}}Creator(15)
-  .then(() => {
-    return new Promise(resolve => {
-      const io = IO(url+'/{{pluralName}}', {query: {orderBy: 'id', order: 'asc'}, forceNew: true});
-      const results = [];
-      io.on('record', data => {
-        results.push(data.new_val);
-      });
-      io.on('state', data => {
-        if (data.state !== 'ready') return;
-        io.disconnect();
-        const reordered = _.clone(results).sort((a, b) => {
-          if (a.id > b.id) return 1;
-          if (a.id < b.id) return -1;
-          return 0;
-        });
-        return resolve(getJSON('/{{pluralName}}?orderBy=id&order=asc')
-        .then(json => {
-          t.deepEqual(_.pluck(reordered, 'id'), _.pluck(json, 'id'));
-        }));
-      });
-    });
-  });
-});
-
-test('websockets should orderBy desc if asked', (t) => {
-  return {{name}}Creator(15)
-  .then(() => {
-    return new Promise(resolve => {
-      const io = IO(url+'/{{pluralName}}', {query: {orderBy: 'id', order: 'desc'}, forceNew: true});
-      const results = [];
-      io.on('record', data => {
-        results.push(data.new_val);
-      });
-      io.on('state', data => {
-        if (data.state !== 'ready') return;
-        io.disconnect();
-        const reordered = _.clone(results).sort((a, b) => {
-          if (a.id < b.id) return 1;
-          if (a.id > b.id) return -1;
-          return 0;
-        });
-        return resolve(getJSON('/{{pluralName}}?orderBy=id&order=desc')
-        .then(json => {
-          t.deepEqual(_.pluck(reordered, 'id'), _.pluck(json, 'id'));
-        }));
-      });
-    });
-  });
-});
 {{#relationships}}
 
 const {{name}}Poster = poster('/{{pluralName}}')

--- a/controller/test.mustache
+++ b/controller/test.mustache
@@ -190,7 +190,6 @@ test('GET /{{pluralName}}?count=true&limit=n should return n matching docs with 
   .then(() => fetch(url+'/{{pluralName}}?count=true&limit=5'))
   .then(res => res.json())
   .then(json => {
-    console.log("json", json)
     t.equal(json.result.length, 5);
     t.ok(json.count);
     t.ok(json.count > 5);

--- a/controller/test.mustache
+++ b/controller/test.mustache
@@ -107,18 +107,15 @@ test('GET /{{pluralName}} should accept search params in the querystring', (t) =
   });
 });
 
-// TODO throw 4xx when invalid property passed to query
-/*test.only('GET /{{pluralName}} should not match non-property search params in the querystring', (t) => {*/
-  /*return {{name}}Creator(2)*/
-  /*.then({{pluralName}} => {*/
-    /*console.log({{pluralName}});*/
-    /*return getJSON('/{{pluralName}}?foo='+{{pluralName}}[0].id)*/
-    /*.then(json => {*/
-      /*console.log("json", json)*/
-      /*t.ok(json.length > 1);*/
-    /*});*/
-  /*});*/
-/*});*/
+test('GET /{{pluralName}} should not match non-property search params in the querystring', (t) => {
+  return {{name}}Creator(2)
+  .then({{pluralName}} => {
+    return getJSON('/{{pluralName}}?foo='+{{pluralName}}[0].id)
+    .then(json => {
+      t.ok(json.length > 1);
+    });
+  });
+});
 
 test('GET /{{pluralName}} should return an array', (t) => {
   return single{{name}}Creator()

--- a/controller/test.mustache
+++ b/controller/test.mustache
@@ -107,15 +107,18 @@ test('GET /{{pluralName}} should accept search params in the querystring', (t) =
   });
 });
 
-test('GET /{{pluralName}} should not match non-property search params in the querystring', (t) => {
-  return {{name}}Creator(2)
-  .then({{pluralName}} => {
-    return getJSON('/{{pluralName}}?foo='+{{pluralName}}[0].id)
-    .then(json => {
-      t.ok(json.length > 1);
-    });
-  });
-});
+// TODO throw 4xx when invalid property passed to query
+/*test.only('GET /{{pluralName}} should not match non-property search params in the querystring', (t) => {*/
+  /*return {{name}}Creator(2)*/
+  /*.then({{pluralName}} => {*/
+    /*console.log({{pluralName}});*/
+    /*return getJSON('/{{pluralName}}?foo='+{{pluralName}}[0].id)*/
+    /*.then(json => {*/
+      /*console.log("json", json)*/
+      /*t.ok(json.length > 1);*/
+    /*});*/
+  /*});*/
+/*});*/
 
 test('GET /{{pluralName}} should return an array', (t) => {
   return single{{name}}Creator()
@@ -190,6 +193,7 @@ test('GET /{{pluralName}}?count=true&limit=n should return n matching docs with 
   .then(() => fetch(url+'/{{pluralName}}?count=true&limit=5'))
   .then(res => res.json())
   .then(json => {
+    console.log("json", json)
     t.equal(json.result.length, 5);
     t.ok(json.count);
     t.ok(json.count > 5);

--- a/controller/tests/lib/controller.mustache
+++ b/controller/tests/lib/controller.mustache
@@ -32,11 +32,11 @@ test('Given params include id, must prioritise id for use as an index', (t) => {
   return t.end();
 })
 
-test('Given params do not match an indexed property, must return null', (t) => {
+test('Given params do not match an indexed property, must return undefined', (t) => {
   const schema = { properties: { id: INDEXED } }
   const params = {farmBoy: true, name: 'Luke Skywalker', pilot: true};
   const result = controller.getIndex(schema, params);
 
-  t.deepEqual(result, null);
+  t.deepEqual(result, undefined);
   return t.end();
 })

--- a/controller/tests/lib/controller.mustache
+++ b/controller/tests/lib/controller.mustache
@@ -1,0 +1,42 @@
+const test = require('blue-tape');
+const controller = require('../../lib/controller');
+
+const INDEXED = {indexed: true}
+const UUID = 'dc83f979-3485-49fc-b180-ba485d01a88f'
+
+test('Given params match an indexed property, must return property name', (t) => {
+  const schema = { properties: { name: INDEXED } }
+  const params = {farmBoy: true, name: 'Luke Skywalker', pilot: true};
+  const result = controller.getIndex(schema, params);
+
+  t.equal(result, "name");
+  return t.end();
+})
+
+test('Given params match multiple indexed properties, must one property name', (t) => {
+  const schema = { properties: { name: INDEXED, pilot: INDEXED } }
+  const params = {farmBoy: true, name: 'Luke Skywalker', pilot: true};
+  const result = controller.getIndex(schema, params);
+
+  // does not matter which indexed property is returned 
+  t.ok(['name', 'pilot'].indexOf(result) > -1)
+  return t.end();
+})
+
+test('Given params include id, must prioritise id for use as an index', (t) => {
+  const schema = { properties: { id: INDEXED, farmBoy: INDEXED } }
+  const params = {id: UUID, farmBoy: true};
+  const result = controller.getIndex(schema, params);
+
+  t.equal(result, "id");
+  return t.end();
+})
+
+test('Given params do not match an indexed property, must return null', (t) => {
+  const schema = { properties: { id: INDEXED } }
+  const params = {farmBoy: true, name: 'Luke Skywalker', pilot: true};
+  const result = controller.getIndex(schema, params);
+
+  t.deepEqual(result, null);
+  return t.end();
+})

--- a/controller/tests/lib/rethinkdb.mustache
+++ b/controller/tests/lib/rethinkdb.mustache
@@ -1,0 +1,65 @@
+const test = require('blue-tape');
+const rethinkdb = require('../../lib/rethinkdb');
+const r = require('../../lib/db');
+const UUID = '8f0834ed-ea58-4be9-8cea-ace9893f9b15';
+
+test('Given no params it should return the query unchanged', (t) => {
+  const query = r.table('test');
+  const result = rethinkdb.buildQuery(query, null, {});
+
+  t.equal(result.toString(), query.toString());
+  return t.end();
+})
+
+test('Given filters it should return a filtered query', (t) => {
+  const query = r.table('test');
+  const filters = {name: 'Darth Vader'}
+  const result = rethinkdb.buildQuery(query, null, filters);
+  const expected = query.filter(filters);
+
+  t.equal(result.toString(), expected.toString());
+  return t.end();
+})
+
+test('Given an indexed field use the index in the query', (t) => {
+  const query = r.table('test');
+  const filters = {name: 'Darth Vader'}
+  const result = rethinkdb.buildQuery(query, 'name', filters);
+  const expected = query.getAll('Darth Vader', {index: 'name'});
+
+  t.equal(result.toString(), expected.toString());
+  return t.end();
+})
+
+test('Given indexed and non-indexed fields it should use index and filter the rest', (t) => {
+  const query = r.table('test');
+  const filters = {
+    name: 'Darth Vader',
+    sith: true
+  };
+  const result = rethinkdb.buildQuery(query, 'name', filters);
+  const expected = query.getAll('Darth Vader', {index: 'name'}).filter({sith: true});
+
+  t.equal(result.toString(), expected.toString());
+  return t.end();
+})
+
+test('Must use .get(x) if an id and no other params provided', (t) => {
+  const query = r.table('test');
+  const filters = {id: UUID};
+  const result = rethinkdb.buildQuery(query, null, filters);
+  const expected = query.get(UUID);
+
+  t.equal(result.toString(), expected.toString());
+  return t.end();
+})
+
+test('Must use .filter(x) if an id and other params provided', (t) => {
+  const query = r.table('test');
+  const filters = {id: UUID, name: 'Luke Skywalker'};
+  const result = rethinkdb.buildQuery(query, null, filters);
+  const expected = query.filter(filters);
+
+  t.equal(result.toString(), expected.toString());
+  return t.end();
+})


### PR DESCRIPTION
This PR adds...
- Refactor controller code to be more DRY (move code into libs shared by API requests and Sockets)
- Automatic query optimisation using table indexes.
- Adds tests for query optimisation
- Add tests for .getIndex(x)
- Refactor the file scaffolders (base/index.js and controller/index.js)

Follow up PRs
- Move scaffold code to render mustache and generate folders/files into separate lib (code is identical)
- Optimise sortBy using indexes (rethinkdb expects different syntax).
- get rid of transformations (limit, skip and sortBy) from sockets, doesn't make sense to me keep these, currently in discussion in Flowdock with Dave.