### PR TITLE
Update required rethink version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@
 
 Redbeard is a scaffolder and _light_ framework for HTTP APIs. It will give you the bones of an API using JSON Schema, Restify, RethinkDB, tape and promise-y functional ES6.
 
-To use it:
+### Development
 
-#### Initial Setup
+#### Requirements
 
+- Rethinkdb 3.0
+
+#### Install
 ```
 npm install -g redbeard
 mdkir my-new-project && cd my-new-project
@@ -42,8 +45,6 @@ This will add the necessary properties to your model schema as well as setup tes
 - - -
 
 NOTES:
-
-* Rethink must be version 2.2 or greater to run the resulting app and/or test suite. Anything earlier doesn't support atomic changefeeds (includeInitial).
 * Project names and model names should be singular, redbeard will pluralize these names as required.
 
 TODO:


### PR DESCRIPTION
There was no issue listed for this, though recently when installing a new `redbeard` project I received the following error:
```
Unhandled rejection ReqlDriverError: Could not parse the message sent by the server : 'ERROR: Received an unsupported protocol version. This port is for RethinkDB queries. Does your client driver version not match the server?
'.
    at Socket.<anonymous> (/Users/winchn/Documents/Projects/_dev/redbeard-test/node_modules/rethinkdbdash/lib/connection.js:171:20)
    at emitOne (events.js:77:13)
    at Socket.emit (events.js:169:7)
    at readableAddChunk (_stream_readable.js:146:16)
    at Socket.Readable.push (_stream_readable.js:110:10)
    at TCP.onread (net.js:523:20)
```

I upgraded rethinkdb from `2.2.6` to `3.0` and it resolved the issue.  Hence, I updated the README.