### PR TITLE
Multi relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,24 @@ And it will add routes, a controller and database bootstrapping. You'll have Cre
 
 ##### Defining Relationships
 
-When creating controllers you also automatically create relationships to other models using the `-r` switch. As with controller model names, the related model names must be singular.
+When creating controllers you also automatically create relationships to other models using the `-s` or `-m` switch.
+
+* `-s` is used for singular relationships (model stores a singular uuid)
+* `-m` is used for multiple relationships (model stores an array of uuids)
+
+As with controller model names, the related model names must be singular.
 
 For example:-
 
 ```
-redbeard controller product -r category,order,warehouse
+redbeard controller product -s category,wholesaler
+```
+OR
+```
+redbeard controller product -m purchaser,location
 ```
 
-This will add the necessary properties to your model schema as well as setup tests to ensure the related model exists.
+This will add the necessary properties to your model schema as well as setup tests to ensure the related model exists (endpoint can be accessed via a GET request).
 
 - - -
 

--- a/controller/lib/schema.mustache
+++ b/controller/lib/schema.mustache
@@ -6,9 +6,15 @@ const schema = require('../schema').getSchema();
 exports.filter = (name, params) => {
   const properties = schema[name].properties;
   return _.reduce(params, (result, value, key) => {
-    if (properties[key]) result[key] = value;
-    return result
-  }, {})
-}
+    const schemaProp = properties[key];
+    if (schemaProp) {
+      // query string will not be cast into an array if a single value was
+      // provided convert it back to an array so query is successful
+      if (schemaProp.type === 'array' && !_.isArray(value)) value = [value];
+      result[key] = value;
+    }
+    return result;
+  }, {});
+};
 
-exports.validate = jsen(schema)
+exports.validate = jsen(schema);

--- a/controller/schema.mustache
+++ b/controller/schema.mustache
@@ -11,23 +11,37 @@
     "name": {
       "type": "string",
       "faker": "name.findName"
-    <%#relationships%>
+    <%#singularRelationships%>
     },
     "<%name%>": {
       "type": "string",
-      "faker": "random.uuid",
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
-    <%/relationships%>
+    <%/singularRelationships%>
+    <%#multiRelationships%>
+    },
+    "<%pluralName%>": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      }
+    <%/multiRelationships%>
     }
   },
   <%#hasRelationships%>
   "links": [
-    <%#relationships%>
+    <%#singularRelationships%>
     {
       "rel": "<%name%>",
       "href": "/<%pluralName%>/{<%name%>}"
+    }<%^isLast%>,<%/isLast%><%#isLast%><%#hasMultiRelationships%>,<%/hasMultiRelationships%><%/isLast%>
+    <%/singularRelationships%>
+    <%#multiRelationships%>
+    {
+      "rel": "<%name%>",
+      "href": "/<%pluralName%>/{<%pluralName%>[]}"
     }<%^isLast%>,<%/isLast%>
-    <%/relationships%>
+    <%/multiRelationships%>
   ],
   <%/hasRelationships%>
   "required": ["name"]

--- a/controller/test.mustache
+++ b/controller/test.mustache
@@ -1,5 +1,6 @@
 "use strict";
 const fetch = require('node-fetch');
+const querystring = require('querystring');
 const _ = require('lodash');
 const fixture = require('../../fixtures/{{name}}');
 const IO = require('socket.io-client');
@@ -62,13 +63,13 @@ const pop = data => data[0];
 const single{{name}}Creator = () => {{name}}Creator(1).then(pop);
 
 {{#relationships}}
-const {{name}}Poster = poster('/{{pluralName}}')
+const {{name}}Poster = poster('/{{pluralName}}');
 
 const {{name}}Creator = times => {
   return Promise.all(_.times(times, () => {
     const data = {{name}}Fixture.valid();
     return {{name}}Poster(data)
-    .then(unwrapJSON)
+    .then(unwrapJSON);
   }));
 };
 
@@ -95,8 +96,10 @@ describe('{{name}} controller', () => {
         .then(entries => {
           const record   = entries[0];
           const property = Object.keys(record).filter(k => k != 'id')[0];
+          if (!property) return; // if no properties other than id skip test
+          const queryStr = querystring.stringify({[property]: record[property]});
 
-          return getJSON('/{{pluralName}}?'+property+'='+record[property])
+          return getJSON('/{{pluralName}}'+'?'+queryStr)
             .then(json => json.map(entry => entry[property]))
             .must.resolve.to.eql([record[property]]);
         });
@@ -207,9 +210,9 @@ describe('{{name}} controller', () => {
 
     {{#relationships}}
     it('saves related entity (can GET using :id)', () => {
-    	return single{{name}}Creator()
-    	  .then(body => fetch(url+'/{{pluralName}}/'+body.id))
-    	  .must.resolve.to.have.property('status', 200);
+      return single{{name}}Creator()
+        .then(body => fetch(url+'/{{pluralName}}/'+body.id))
+        .must.resolve.to.have.property('status', 200);
     });
     {{/relationships}}
   });

--- a/lib/yargs.js
+++ b/lib/yargs.js
@@ -16,11 +16,22 @@ if (!VALID_NAME.test(opts.name)) {
 opts.pluralName = opts.name ? pluralize(opts.name) : null;
 
 // reformat relationships into a format usable within mustache (an obj array)
-if (opts.r != null) {
+if (opts.s || opts.m) {
   opts.hasRelationships = true;
-  var relationships = toArray(opts.r, "name");
-  opts.relationships = pluralizeArray(relationships);
-  delete opts.r;
+  const relationships = _.compact([opts.s, opts.m]).join(',');
+  opts.relationships = pluralizeArray(toArray(relationships, "name"));
+  console.log(opts.relationships)
+
+  if (opts.s) {
+    opts.hasSingularRelationships = true;
+    opts.singularRelationships = pluralizeArray(toArray(opts.s, "name"));
+    delete opts.s;
+  }
+  if (opts.m) {
+    opts.hasMultiRelationships = true;
+    opts.multiRelationships = pluralizeArray(toArray(opts.m, "name"));
+    delete opts.m;
+  }
 }
 
 opts = _.omit(opts, ["_", "$0"]);

--- a/test.js
+++ b/test.js
@@ -22,11 +22,13 @@ const index = path.join(__dirname, 'index.js');
 const appName = 'redbeard_tests'+randomstring();
 const controllerName1 = randomstring();
 const controllerName2 = randomstring();
+const controllerName3 = randomstring();
 
 exec(['node', index, 'base', appName].join(' '), opts);
 if (process.env.SLOW_TEST) exec(['npm', 'install'].join(' '), opts);
 exec(['node', index, 'controller', controllerName1].join(' '), opts);
-exec(['node', index, 'controller', controllerName2, '-r', controllerName1].join(' '), opts);
+exec(['node', index, 'controller', controllerName2, '-s', controllerName1].join(' '), opts);
+exec(['node', index, 'controller', controllerName3, '-m', controllerName2].join(' '), opts);
 exec(['node', index, 'cors'].join(' '), opts);
 exec(['npm', 'test'].join(' '), opts);
 


### PR DESCRIPTION
This PR adds support for one-to-many relationships in redbeard `-m`. The previous implementation only supported one-to-one relationships.

Note: for `controller/lib/schema.mustache` I want to add a test, but my tests have been nuked by a prior merge so I'll submit a PR to reintroduce them then I can add a test for this.