### PR TITLE
Re add deleted tests

### DIFF
--- a/controller/index.js
+++ b/controller/index.js
@@ -1,6 +1,5 @@
 const scaffold = require('../lib/scaffold');
 
-
 module.exports = (opts) => {
   // p: source path, n: filename
   // d: destination path, t: target filename, e: target extension
@@ -8,6 +7,8 @@ module.exports = (opts) => {
     {p: 'lib', n: 'controller'},
     {p: 'lib', n: 'rethinkdb'},
     {p: 'lib', n: 'schema'},
+    {p: 'test/lib', n: 'controller'},
+    {p: 'test/lib', n: 'rethinkdb'},
     {n: 'controller', d: 'controllers', t: opts.name},
     {n: 'test', d: 'test/controllers', t: opts.name+'_test'},
     {n: 'route', d: 'routes', t: opts.name},

--- a/controller/test/lib/controller.mustache
+++ b/controller/test/lib/controller.mustache
@@ -1,0 +1,44 @@
+const controller = require('../../lib/controller');
+
+const INDEXED = {indexed: true}
+const UUID = 'dc83f979-3485-49fc-b180-ba485d01a88f'
+
+describe('lib/controller', function() {
+  describe('.getIndexes', function() {
+    it('Given params match indexed properties, must return all matches', () => {
+      const schema = { properties: { favMilk: INDEXED, pilot: INDEXED } }
+      const params = {
+        favMilk: 'blue',
+        id: UUID,
+        name: 'Luke Skywalker',
+        pilot: true
+      };
+      const result = controller.getIndexes(schema, params);
+      result.must.eql(["favMilk", "pilot"]);
+    })
+
+    it('Given indexed properties that are not in params must not return these', () => {
+      const schema = {
+        properties: {pilot: INDEXED, sonOfVader: INDEXED, saberColour: INDEXED}
+      }
+      const params = {
+        favMilk: 'blue',
+        id: UUID,
+        name: 'Luke Skywalker',
+        pilot: true
+      };
+      const result = controller.getIndexes(schema, params);
+      result.must.eql(["pilot"]);
+    })
+
+    it('Given no params match indexed propertites, must return an empty array', () => {
+      const schema = { properties: { favMilk: INDEXED, pilot: INDEXED } }
+      const params = {
+        sonOfVader: true,
+        saberColour: 'green/blue'
+      };
+      const result = controller.getIndexes(schema, params);
+      result.must.eql([]);
+    })
+  })
+})

--- a/controller/test/lib/rethinkdb.mustache
+++ b/controller/test/lib/rethinkdb.mustache
@@ -1,0 +1,181 @@
+const rethinkdb = require('../../lib/rethinkdb');
+const r = require('../../lib/db');
+const UUID = '8f0834ed-ea58-4be9-8cea-ace9893f9b15';
+
+describe('lib/rethinkdb', function() {
+  describe('.buildQuery', function() {
+    it('Given no params it should return the query unchanged', () => {
+      const query = r.table('test');
+      const result = rethinkdb.buildQuery(query, null, {});
+
+      result.toString().must.equal(query.toString());
+    })
+
+    it('Given filters it should return a filtered query', () => {
+      const query = r.table('test');
+      const filters = {name: 'Darth Vader'}
+      const result = rethinkdb.buildQuery(query, null, filters);
+      const expected = query.filter(filters);
+
+      result.toString().must.equal(expected.toString());
+    })
+
+    it('Given an indexed field use the index in the query', () => {
+      const query = r.table('test');
+      const filters = {name: 'Darth Vader'}
+      const result = rethinkdb.buildQuery(query, 'name', filters);
+      const expected = query.getAll('Darth Vader', {index: 'name'});
+
+      result.toString().must.equal(expected.toString());
+    })
+
+    it('Given indexed and non-indexed fields it should use index and filter the rest', () => {
+      const query = r.table('test');
+      const filters = {
+        name: 'Darth Vader',
+        sith: true
+      };
+      const result = rethinkdb.buildQuery(query, 'name', filters);
+      const expected = query.getAll('Darth Vader', {index: 'name'}).filter({sith: true});
+
+      result.toString().must.equal(expected.toString());
+    })
+
+    it('Must use .get(x) if an id and no other params provided', () => {
+      const query = r.table('test');
+      const filters = {id: UUID};
+      const result = rethinkdb.buildQuery(query, null, filters);
+      const expected = query.get(UUID);
+
+      result.toString().must.equal(expected.toString());
+    })
+
+    it('Must use .filter(x) if an id and other params provided', () => {
+      const query = r.table('test');
+      const filters = {id: UUID, name: 'Luke Skywalker'};
+      const result = rethinkdb.buildQuery(query, null, filters);
+      const expected = query.filter(filters);
+
+      result.toString().must.equal(expected.toString());
+    })
+  })
+
+  describe('.addTransformations', function() {
+    it('Given skip in params, must apply this to the query', () => {
+      const query = r.table('test');
+      const params = {skip: 5};
+      const result = rethinkdb.addTransformations(query, [], params);
+
+      const expected = query.skip(5);
+      result.toString().must.equal(expected.toString());
+    })
+
+    it('Given limit in params, must apply this to the query', () => {
+      const query = r.table('test');
+      const params = {limit: 5};
+      const result = rethinkdb.addTransformations(query, [], params);
+
+      const expected = query.limit(5);
+      result.toString().must.equal(expected.toString());
+    })
+
+    it('Given orderBy in params, must apply this to query and default to ascending', () => {
+      const query = r.table('test');
+      const params = {orderBy: "name"};
+      const result = rethinkdb.addTransformations(query, [], params);
+
+      const expected = query.orderBy(r.asc("name"));
+      result.toString().must.equal(expected.toString());
+    })
+
+    it('Given order is provided, must sort accordingly', () => {
+      const query = r.table('test');
+      const params = {orderBy: "name", order: "desc"};
+      const result = rethinkdb.addTransformations(query, [], params);
+
+      const expected = query.orderBy(r.desc("name"));
+      result.toString().must.equal(expected.toString());
+    })
+
+    it('Given orderBy is provided and field is indexed, it must use index', () => {
+      const query = r.table('test');
+      const params = {orderBy: "name"};
+      const result = rethinkdb.addTransformations(query, ["orderBy"], params);
+
+      const expected = query.orderBy({index: r.asc("name")});
+      result.toString().must.equal(expected.toString());
+    })
+
+    it('Given orderBy and order is provided for indexed field, sort order must be used', () => {
+      const query = r.table('test');
+      const params = {orderBy: "name", order: "desc"};
+      const result = rethinkdb.addTransformations(query, ["orderBy"], params);
+
+      const expected = query.orderBy({index: r.desc("name")});
+      result.toString().must.equal(expected.toString());
+    })
+  })
+
+  describe('.isChangeFeedable', function() {
+    it('Given a query using orderBy without limit, it must return false', () => {
+      const table = r.table('test');
+      const query = table.orderBy('name');
+
+      const result = rethinkdb.isChangeFeedable(query);
+      result.must.equal(result, false);
+    })
+
+    it('Given a query using limit without orderBy, it must return false', () => {
+      const table = r.table('test');
+      const query = table.limit(1);
+
+      const result = rethinkdb.isChangeFeedable(query);
+      result.must.equal(result, false);
+    })
+
+    // this issue is not documented but causes the same problem as limit without orderBy
+    it('Given a query using skip without orderBy, it must return false', () => {
+      const table = r.table('test');
+      const query = table.skip(1);
+
+      const result = rethinkdb.isChangeFeedable(query);
+      result.must.equal(false);
+    })
+
+    it('Given a query using orderBy without an index, it must return false', () => {
+      const table = r.table('test');
+      const query = table.limit(1).orderBy('name');
+
+      const result = rethinkdb.isChangeFeedable(query);
+      result.must.equal(false);
+    })
+
+    it('Given a query using orderBy with an index, it must return true', () => {
+      const table = r.table('test');
+
+      const query = table.limit(1).orderBy({index: 'name'});
+      const result = rethinkdb.isChangeFeedable(query)
+      result.must.equal(true);
+
+      const query2 = table.limit(1).orderBy({index: r.desc('date')});
+      const result2 = rethinkdb.isChangeFeedable(query);
+      result.must.equal(true);
+    })
+
+    it('Given a query using filter before orderBy, it must return true', () => {
+      const table = r.table('test');
+
+      const query = table.filter({name: 'Darh Vader'}).limit(1).orderBy({index: 'name'});
+      const result = rethinkdb.isChangeFeedable(query)
+      result.must.equal(true);
+    })
+
+    it('Given a query using filter after orderBy, it must return false', () => {
+      const table = r.table('test');
+
+      const query = table.limit(1).orderBy({index: 'name'}).filter({name: 'Darh Vader'});
+      const result = rethinkdb.isChangeFeedable(query)
+      result.must.equal(false);
+    })
+  })
+})

--- a/controller/test/lib/rethinkdb.mustache
+++ b/controller/test/lib/rethinkdb.mustache
@@ -4,14 +4,14 @@ const UUID = '8f0834ed-ea58-4be9-8cea-ace9893f9b15';
 
 describe('lib/rethinkdb', function() {
   describe('.buildQuery', function() {
-    it('Given no params it should return the query unchanged', () => {
+    it('must return an unchanged query given no params', () => {
       const query = r.table('test');
       const result = rethinkdb.buildQuery(query, null, {});
 
       result.toString().must.equal(query.toString());
     })
 
-    it('Given filters it should return a filtered query', () => {
+    it('must return a filered query given filters', () => {
       const query = r.table('test');
       const filters = {name: 'Darth Vader'}
       const result = rethinkdb.buildQuery(query, null, filters);
@@ -20,7 +20,7 @@ describe('lib/rethinkdb', function() {
       result.toString().must.equal(expected.toString());
     })
 
-    it('Given an indexed field use the index in the query', () => {
+    it('must use an index when filters use an indexed property', () => {
       const query = r.table('test');
       const filters = {name: 'Darth Vader'}
       const result = rethinkdb.buildQuery(query, 'name', filters);
@@ -29,7 +29,7 @@ describe('lib/rethinkdb', function() {
       result.toString().must.equal(expected.toString());
     })
 
-    it('Given indexed and non-indexed fields it should use index and filter the rest', () => {
+    it('must use an index when filters use an indexed property and .filter(x) any others', () => {
       const query = r.table('test');
       const filters = {
         name: 'Darth Vader',
@@ -41,7 +41,7 @@ describe('lib/rethinkdb', function() {
       result.toString().must.equal(expected.toString());
     })
 
-    it('Must use .get(x) if an id and no other params provided', () => {
+    it('must use .get(x) when an id and no other params provided', () => {
       const query = r.table('test');
       const filters = {id: UUID};
       const result = rethinkdb.buildQuery(query, null, filters);
@@ -50,7 +50,7 @@ describe('lib/rethinkdb', function() {
       result.toString().must.equal(expected.toString());
     })
 
-    it('Must use .filter(x) if an id and other params provided', () => {
+    it('must use .filter(x) when an id and other params provided', () => {
       const query = r.table('test');
       const filters = {id: UUID, name: 'Luke Skywalker'};
       const result = rethinkdb.buildQuery(query, null, filters);
@@ -61,7 +61,7 @@ describe('lib/rethinkdb', function() {
   })
 
   describe('.addTransformations', function() {
-    it('Given skip in params, must apply this to the query', () => {
+    it('must apply .skip(x) when params contain skip', () => {
       const query = r.table('test');
       const params = {skip: 5};
       const result = rethinkdb.addTransformations(query, [], params);
@@ -70,7 +70,7 @@ describe('lib/rethinkdb', function() {
       result.toString().must.equal(expected.toString());
     })
 
-    it('Given limit in params, must apply this to the query', () => {
+    it('must apply .limit(x) when params contain limit', () => {
       const query = r.table('test');
       const params = {limit: 5};
       const result = rethinkdb.addTransformations(query, [], params);
@@ -79,7 +79,7 @@ describe('lib/rethinkdb', function() {
       result.toString().must.equal(expected.toString());
     })
 
-    it('Given orderBy in params, must apply this to query and default to ascending', () => {
+    it('must apply .orderBy(x) when params contain orderBy and default to ascending', () => {
       const query = r.table('test');
       const params = {orderBy: "name"};
       const result = rethinkdb.addTransformations(query, [], params);
@@ -88,7 +88,7 @@ describe('lib/rethinkdb', function() {
       result.toString().must.equal(expected.toString());
     })
 
-    it('Given order is provided, must sort accordingly', () => {
+    it('must apply sort order to orderBy when params contain order', () => {
       const query = r.table('test');
       const params = {orderBy: "name", order: "desc"};
       const result = rethinkdb.addTransformations(query, [], params);
@@ -97,7 +97,7 @@ describe('lib/rethinkdb', function() {
       result.toString().must.equal(expected.toString());
     })
 
-    it('Given orderBy is provided and field is indexed, it must use index', () => {
+    it('must apply an index to orderBy when using an indexed property', () => {
       const query = r.table('test');
       const params = {orderBy: "name"};
       const result = rethinkdb.addTransformations(query, ["orderBy"], params);
@@ -106,7 +106,7 @@ describe('lib/rethinkdb', function() {
       result.toString().must.equal(expected.toString());
     })
 
-    it('Given orderBy and order is provided for indexed field, sort order must be used', () => {
+    it('must apply an index and sort order to orderBy when using an indexed property', () => {
       const query = r.table('test');
       const params = {orderBy: "name", order: "desc"};
       const result = rethinkdb.addTransformations(query, ["orderBy"], params);
@@ -117,7 +117,7 @@ describe('lib/rethinkdb', function() {
   })
 
   describe('.isChangeFeedable', function() {
-    it('Given a query using orderBy without limit, it must return false', () => {
+    it('must return false when given a query using orderBy without limit', () => {
       const table = r.table('test');
       const query = table.orderBy('name');
 
@@ -125,7 +125,7 @@ describe('lib/rethinkdb', function() {
       result.must.equal(result, false);
     })
 
-    it('Given a query using limit without orderBy, it must return false', () => {
+    it('must return false when given a query using limit without orderBy', () => {
       const table = r.table('test');
       const query = table.limit(1);
 
@@ -134,7 +134,7 @@ describe('lib/rethinkdb', function() {
     })
 
     // this issue is not documented but causes the same problem as limit without orderBy
-    it('Given a query using skip without orderBy, it must return false', () => {
+    it('must return false when given a query using skip without orderBy', () => {
       const table = r.table('test');
       const query = table.skip(1);
 
@@ -142,7 +142,7 @@ describe('lib/rethinkdb', function() {
       result.must.equal(false);
     })
 
-    it('Given a query using orderBy without an index, it must return false', () => {
+    it('must return false when given a query using orderBy without an index', () => {
       const table = r.table('test');
       const query = table.limit(1).orderBy('name');
 
@@ -150,7 +150,7 @@ describe('lib/rethinkdb', function() {
       result.must.equal(false);
     })
 
-    it('Given a query using orderBy with an index, it must return true', () => {
+    it('must return true when given a query using orderBy with an index', () => {
       const table = r.table('test');
 
       const query = table.limit(1).orderBy({index: 'name'});
@@ -162,7 +162,7 @@ describe('lib/rethinkdb', function() {
       result.must.equal(true);
     })
 
-    it('Given a query using filter before orderBy, it must return true', () => {
+    it('must return true when given a filter before limit and orderBy', () => {
       const table = r.table('test');
 
       const query = table.filter({name: 'Darh Vader'}).limit(1).orderBy({index: 'name'});
@@ -170,7 +170,7 @@ describe('lib/rethinkdb', function() {
       result.must.equal(true);
     })
 
-    it('Given a query using filter after orderBy, it must return false', () => {
+    it('must return false when given a filter after limit and orderBy', () => {
       const table = r.table('test');
 
       const query = table.limit(1).orderBy({index: 'name'}).filter({name: 'Darh Vader'});


### PR DESCRIPTION
This PR re-adds the tests that got nuked and converts them to mocha / must syntax.
I assume these were somehow deleted in the blue-tape => mocha change.

Deleted files...
https://github.com/Prismatik/redbeard/commit/93de0ec2aff092b900382bf6bd65cead8cd1b7b8
controller/tests/lib/controller.mustache
controller/tests/lib/rethinkdb.mustache