### PR TITLE
Socket middleware

### DIFF
--- a/base/index.mustache
+++ b/base/index.mustache
@@ -10,7 +10,9 @@ app.use(bodyParser.json());
 app.use(cors());
 
 fs.readdirSync('./middleware').forEach(name => {
-  app.use(require(`./middleware/${name}`));
+  const middleware = require(`./middleware/${name}`);
+  if (middleware.http) app.use(middleware.http);
+  if (middleware.socket) io.use(middleware.socket);
 });
 
 fs.readdirSync('./routes').forEach(name => {

--- a/base/index.mustache
+++ b/base/index.mustache
@@ -18,7 +18,7 @@ fs.readdirSync('./middleware').forEach(name => {
 fs.readdirSync('./routes').forEach(name => {
   const route = require(`./routes/${name}`);
   app.use(route.http);
-  route.ws(io);
+  route.socket(io);
 });
 
 app.use((err, req, res) => {

--- a/base/routes/jwt.mustache
+++ b/base/routes/jwt.mustache
@@ -18,5 +18,5 @@ module.exports = {
       res.sendStatus(200);
       return next();
     }),
-  ws: () => {}
+  socket: () => {}
 };

--- a/base/routes/schema.mustache
+++ b/base/routes/schema.mustache
@@ -4,5 +4,5 @@ const schema = require('schema').getSchema();
 module.exports = {
   http: Router()
     .get('/schema', (req, res) => res.json(schema)),
-  ws: () => {}
+  socket: () => {}
 };

--- a/controller/route.mustache
+++ b/controller/route.mustache
@@ -21,7 +21,7 @@ const respond = (res, status) => body => {
 
 module.exports = {
   http: router,
-  ws: io => {
+  socket: io => {
     const nsp = io.of('/{{pluralName}}');
     nsp.on('connection', socket => {
       {{name}}Controller.watch(socket.handshake.query)

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -1,0 +1,9 @@
+const scaffold = require('../lib/scaffold');
+
+module.exports = (opts) => {
+  const files = [
+    {p: 'middleware', n: 'template', t: opts.name}
+  ];
+
+  scaffold({ basePath: __dirname, files: files, mustacheOpts: opts });
+};

--- a/middleware/middleware/template.mustache
+++ b/middleware/middleware/template.mustache
@@ -1,0 +1,4 @@
+module.exports = {
+  http: (req, res, next) => {},
+  socket: (socket, next) => {}
+};


### PR DESCRIPTION
Change to the way we export standard middleware functions. Instead of exporting a single function, we now export an object with `http` and `socket` properties. Each of these is a function that takes the http server and the socket server respectively. They can then glom middleware onto it.