### PR TITLE
generate schemas folder when running base so tests pass

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -37,7 +37,8 @@ module.exports = (opts) => {
   const dirs = [
     'env',
     'routes',
-    'migrations'
+    'migrations',
+    'schemas'
   ].forEach(dir => mkdirp.sync(dir));
 
   const modulesDir = path.join(process.cwd(), 'node_modules');


### PR DESCRIPTION
This PR fixes an issue where if you scaffold out `base` only and no `controllers` the tests will fail. To fix this I've just added the missing `/schemas` folder.