### PR TITLE
Revisions

### DIFF
--- a/base/package.mustache
+++ b/base/package.mustache
@@ -25,7 +25,8 @@
     "rethinkdbdash": "^2.2.8",
     "simple-password": "^1.0.1",
     "socket.io": "^1.3.7",
-    "standard-http-error": "^2.0.0"
+    "standard-http-error": "^2.0.0",
+    "uuid": "^2.0.2"
   },
   "devDependencies": {
     "mocha": "^2.4.5",

--- a/controller/controller.mustache
+++ b/controller/controller.mustache
@@ -75,13 +75,10 @@ module.exports = {
     if (!valid) throw new httpError('UNPROCESSABLE_ENTITY');
     return r.table('{{pluralName}}')
     .get({{name}}.id)
-    .update(doc => {
-      return r.branch(
-        doc('rev').eq({{name}}.rev),
-        {{name}},
-        r.error('rev does not match')
-      )
-    }, {returnChanges: true})
+    .update(
+      rethinkdb.ifRevMatches({{name}}),
+      {returnChanges: true}
+    )
     .run()
     .then(rethinkdb.checkRevError)
     .then(rethinkdb.firstChange);
@@ -111,13 +108,10 @@ module.exports = {
       if (!valid) throw new httpError('UNPROCESSABLE_ENTITY');
       return r.table('{{pluralName}}')
       .get({{name}}.id)
-      .update(doc => {
-        return r.branch(
-          doc('rev').eq({{name}}.rev),
-          {{name}},
-          r.error('rev does not match')
-        )
-      }, {returnChanges: true})
+      .update(
+        rethinkdb.ifRevMatches({{name}}),
+        {returnChanges: true}
+      )
       .run()
       .then(rethinkdb.checkRevError)
       .then(rethinkdb.firstChange);

--- a/controller/controller.mustache
+++ b/controller/controller.mustache
@@ -83,12 +83,7 @@ module.exports = {
       )
     }, {returnChanges: true})
     .run()
-    .then(res => {
-      if (res.first_error === 'rev does not match') {
-        throw new httpError('BAD_REQUEST', res.first_error);
-      };
-      return res;
-    })
+    .then(rethinkdb.checkRevError)
     .then(rethinkdb.firstChange);
   },
   {{/isUser}}
@@ -124,12 +119,7 @@ module.exports = {
         )
       }, {returnChanges: true})
       .run()
-      .then(res => {
-        if (res.first_error === 'rev does not match') {
-          throw new httpError('BAD_REQUEST', res.first_error);
-        };
-        return res;
-      })
+      .then(rethinkdb.checkRevError)
       .then(rethinkdb.firstChange);
     });
   },

--- a/controller/controller.mustache
+++ b/controller/controller.mustache
@@ -70,7 +70,7 @@ module.exports = {
   update: ({{name}}) => {
     const valid = schema.validate({{name}});
     if (!valid) throw new httpError('UNPROCESSABLE_ENTITY');
-    return r.table('{{pluralName}}').update({{name}}, {returnChanges: true}).run()
+    return r.table('{{pluralName}}').get({{name}}.id).update({{name}}, {returnChanges: true}).run()
     .then(rethinkdb.firstChange);
   },
   {{/isUser}}
@@ -94,7 +94,7 @@ module.exports = {
       if (pass) {{name}}.password = pass;
       const valid = schema.validate({{name}});
       if (!valid) throw new httpError('UNPROCESSABLE_ENTITY');
-      return r.table('{{pluralName}}').update({{name}}, {returnChanges: true}).run()
+      return r.table('{{pluralName}}').get({{name}}.id).update({{name}}, {returnChanges: true}).run()
       .then(rethinkdb.firstChange);
     });
   },

--- a/controller/controller.mustache
+++ b/controller/controller.mustache
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const httpError = require('standard-http-error');
+const uuid = require('uuid');
 const r = require('../lib/db');
 const controller = require('../lib/controller');
 const rethinkdb = require('../lib/rethinkdb');
@@ -64,13 +65,30 @@ module.exports = {
   create: ({{name}}) => {
     const valid = schema.validate({{name}});
     if (!valid) throw new httpError('UNPROCESSABLE_ENTITY');
+    {{name}}.rev = uuid.v4();
     return r.table('{{pluralName}}').insert({{name}}, {returnChanges: true}).run()
     .then(rethinkdb.firstChange);
   },
   update: ({{name}}) => {
+    if (!{{name}}.rev) return Promise.reject(new httpError('BAD_REQUEST', 'No rev provided'));
     const valid = schema.validate({{name}});
     if (!valid) throw new httpError('UNPROCESSABLE_ENTITY');
-    return r.table('{{pluralName}}').get({{name}}.id).update({{name}}, {returnChanges: true}).run()
+    return r.table('{{pluralName}}')
+    .get({{name}}.id)
+    .update(doc => {
+      return r.branch(
+        doc('rev').eq({{name}}.rev),
+        {{name}},
+        r.error('rev does not match')
+      )
+    }, {returnChanges: true})
+    .run()
+    .then(res => {
+      if (res.first_error === 'rev does not match') {
+        throw new httpError('BAD_REQUEST', res.first_error);
+      };
+      return res;
+    })
     .then(rethinkdb.firstChange);
   },
   {{/isUser}}
@@ -81,11 +99,13 @@ module.exports = {
       const data = _.merge({{name}}, {password: hash});
       const valid = schema.validate(data);
       if (!valid) throw new httpError('UNPROCESSABLE_ENTITY');
+      {{name}}.rev = uuid.v4();
       return r.table('{{pluralName}}').insert(data, {returnChanges: true}).run()
       .then(rethinkdb.firstChange);
     });
   },
   update: ({{name}}) => {
+    if (!{{name}}.rev) return Promise.reject(new httpError('BAD_REQUEST', 'No rev provided'));
     var getHash;
     if ({{name}}.password) getHash = password.create({{name}}.password, 10);
     else getHash = Promise.resolve();
@@ -94,7 +114,22 @@ module.exports = {
       if (pass) {{name}}.password = pass;
       const valid = schema.validate({{name}});
       if (!valid) throw new httpError('UNPROCESSABLE_ENTITY');
-      return r.table('{{pluralName}}').get({{name}}.id).update({{name}}, {returnChanges: true}).run()
+      return r.table('{{pluralName}}')
+      .get({{name}}.id)
+      .update(doc => {
+        return r.branch(
+          doc('rev').eq({{name}}.rev),
+          {{name}},
+          r.error('rev does not match')
+        )
+      }, {returnChanges: true})
+      .run()
+      .then(res => {
+        if (res.first_error === 'rev does not match') {
+          throw new httpError('BAD_REQUEST', res.first_error);
+        };
+        return res;
+      })
       .then(rethinkdb.firstChange);
     });
   },

--- a/controller/lib/rethinkdb.mustache
+++ b/controller/lib/rethinkdb.mustache
@@ -72,3 +72,13 @@ exports.checkRevError = res => {
   };
   return res;
 }
+
+exports.ifRevMatches = update => {
+  return doc => {
+    return r.branch(
+      doc('rev').eq(update.rev),
+      update,
+      r.error('rev does not match')
+    )
+  }
+}

--- a/controller/lib/rethinkdb.mustache
+++ b/controller/lib/rethinkdb.mustache
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const r = require('./db');
+const httpError = require('standard-http-error');
 
 const limitRegexp = /\.limit\(([^\)]*)\)/m;
 const orderByRegexp = /\.orderBy\(([^\)]*)\)/m;
@@ -63,4 +64,11 @@ exports.isChangeFeedable = (query) => {
   if (orderBy && orderBy[1].indexOf('index') === -1) return false;
   if (filter && orderBy && filter.index > orderBy.index) return false;
   return true;
+}
+
+exports.checkRevError = res => {
+  if (res.first_error === 'rev does not match') {
+    throw new httpError('BAD_REQUEST', res.first_error);
+  };
+  return res;
 }

--- a/controller/schema.mustache
+++ b/controller/schema.mustache
@@ -8,6 +8,10 @@
       "type": "string",
       "faker": "random.uuid"
     },
+    "rev": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{32}$/i"
+    },
     "name": {
       "type": "string",
       "faker": "name.findName"

--- a/controller/test.mustache
+++ b/controller/test.mustache
@@ -239,17 +239,31 @@ describe('{{name}} controller', () => {
     it('updates {{name}} and actually persists it', () => {
       const update = {name: 'Something else'};
       return single{{name}}Creator()
-        .then(body => putter('/{{pluralName}}/'+body.id)(update))
+        .then(body => putter('/{{pluralName}}/'+body.id)(_.merge(body, update)))
         .then(unwrapJSON)
         .then(body => getJSON('/{{pluralName}}/'+body.id))
         .must.resolve.to.have.property('name', update.name);
+    });
+
+    it('rejects a {{name}} without any rev', () => {
+      const update = {name: 'Something else'};
+      return single{{name}}Creator()
+        .then(body => putter('/{{pluralName}}/'+body.id)(update))
+        .then(res => res.status.must.equal(400));
+    });
+
+    it('rejects a {{name}} with a faulty rev', () => {
+      const update = {name: 'Something else', rev: 'foo'};
+      return single{{name}}Creator()
+        .then(body => putter('/{{pluralName}}/'+body.id)(_.merge(body, update)))
+        .then(res => res.status.must.equal(400));
     });
     {{#isUser}}
 
     it('PUTing an updated password should update the password hash', () => {
       const update = {password: 'ABCD1234'};
       return single{{name}}Creator()
-      .then(body => putter('/{{pluralName}}/'+body.id)(update))
+      .then(body => putter('/{{pluralName}}/'+body.id)(_.merge(body, update)))
       .then(unwrapJSON)
       .then(body => getJSON('/{{pluralName}}/'+body.id))
       .then(json => password.verify(update.password, json.password))

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "simple-password": "^1.0.1",
     "socket.io": "^1.3.7",
     "socket.io-client": "^1.3.7",
-    "standard-http-error": "^2.0.0"
+    "standard-http-error": "^2.0.0",
+    "uuid": "^2.0.2"
   },
   "engines": {
     "node": "^6.1.0",


### PR DESCRIPTION
Adds basic revision IDs to all documents and demands they be provided before it will allow any changes to be made.

This ensures sanity when multiple writers are updating a single document to ensure that changes are not overwritten unwittingly.

Also includes a pretty major bugfix. Due to a missing reql statement any previous calls to `update` would have copied that document across the entire table. Hey-ho.