### PR TITLE
Fixes migration creation.

### DIFF
--- a/base/bin/migration.mustache
+++ b/base/bin/migration.mustache
@@ -7,16 +7,17 @@ const migrationName = `${now}_${process.argv[2]}`;
 const opts = { migrationName };
 
 const migrationTemplate = fs.readFileSync('./bin/migration_template.mustache').toString();
-const migrationTestTemplate = fs.readFileSync('./bin/migration_test_template.mustache').toString();
+const migrationTestTemplate = fs.readFileSync('./bin/migration_template_test.mustache').toString();
 
 const migrationFile = mustache.render(migrationTemplate, opts);
 const migrationTest = mustache.render(migrationTestTemplate, opts);
 
 try {
-  fs.mkdirSync('./tests/migrations/');
+  fs.mkdirSync('./migrations/');
+  fs.mkdirSync('./test/migrations/');
 } catch (e) {
   if (e.code !== 'EEXIST') throw e;
 }
 
 fs.writeFileSync(`./migrations/${migrationName}.js`, migrationFile);
-fs.writeFileSync(`./tests/migrations/${migrationName}.js`, migrationTest);
+fs.writeFileSync(`./test/migrations/${migrationName}.js`, migrationTest);

--- a/base/bin/migration.mustache
+++ b/base/bin/migration.mustache
@@ -12,7 +12,7 @@ const migrationTestTemplate = fs.readFileSync('./bin/migration_template_test.mus
 const migrationFile = mustache.render(migrationTemplate, opts);
 const migrationTest = mustache.render(migrationTestTemplate, opts);
 
-['./migrations/', './test/migrations'].forEach(p => {
+['./migrations/', './test/migrations/'].forEach(p => {
   try {
     fs.mkdirSync(p);
   } catch (e) {

--- a/base/bin/migration.mustache
+++ b/base/bin/migration.mustache
@@ -12,12 +12,13 @@ const migrationTestTemplate = fs.readFileSync('./bin/migration_template_test.mus
 const migrationFile = mustache.render(migrationTemplate, opts);
 const migrationTest = mustache.render(migrationTestTemplate, opts);
 
-try {
-  fs.mkdirSync('./migrations/');
-  fs.mkdirSync('./test/migrations/');
-} catch (e) {
-  if (e.code !== 'EEXIST') throw e;
-}
+['./migrations/', './test/migrations'].forEach(p => {
+  try {
+    fs.mkdirSync(p);
+  } catch (e) {
+    if (e.code !== 'EEXIST') throw e;
+  }
+});
 
 fs.writeFileSync(`./migrations/${migrationName}.js`, migrationFile);
 fs.writeFileSync(`./test/migrations/${migrationName}.js`, migrationTest);


### PR DESCRIPTION
This corrects a couple issues. It will now look in the correct location for the migration template; it will write to the correct /test/ directory, and will also create the ./migrations folder if none previously exists, but won't create an extra if it does already exist.