### PR TITLE
fix comment indentation for eslint

### DIFF
--- a/model/table.mustache
+++ b/model/table.mustache
@@ -10,9 +10,9 @@ module.exports = () => {
   .then(() => {
     r.table('{{pluralName}}').wait().run();
   });
-  //.then(() => r.table('{{pluralName}}').indexCreate('name').run())
-  //.catch(err => {
-  //  if (err.message.indexOf('Index `name` already exists') > -1 ) return;
-  //  throw err;
-  //});
+  // .then(() => r.table('{{pluralName}}').indexCreate('name').run())
+  // .catch(err => {
+  //   if (err.message.indexOf('Index `name` already exists') > -1 ) return;
+  //   throw err;
+  // });
 };


### PR DESCRIPTION
eslint (at least the prismatik config and I guess the airbnb one as well) wants a space between the `//` and the comment.