### PR TITLE
Fixture omissions

### DIFF
--- a/model/fixture.mustache
+++ b/model/fixture.mustache
@@ -6,19 +6,12 @@ const schema = appSchema.{{camelCase}};
 const bandname = require('bandname');
 {{/isUser}}
 
-{{^isUser}}
 module.exports = {
   valid: (omissions) => {
-    return _.omit(generate(schema), omissions);
+    const v = generate(schema);
+    {{#isUser}}
+    v.password = bandname();
+    {{/isUser}}
+    return _.omit(v, omissions);
   }
 };
-{{/isUser}}
-{{#isUser}}
-module.exports = {
-  valid: (omissions) => {
-    const user = generate(schema);
-    user.password = bandname();
-    return _.omit(user, omissions);
-  }
-};
-{{/isUser}}

--- a/model/fixture.mustache
+++ b/model/fixture.mustache
@@ -1,4 +1,5 @@
 const generate = require('json-schema-faker');
+const _ = require('lodash');
 const appSchema = require('../schema.js').getSchema();
 const schema = appSchema.{{camelCase}};
 {{#isUser}}
@@ -7,15 +8,17 @@ const bandname = require('bandname');
 
 {{^isUser}}
 module.exports = {
-  valid: () => generate(schema)
+  valid: (omissions) => {
+    return _.omit(generate(schema), omissions);
+  }
 };
 {{/isUser}}
 {{#isUser}}
 module.exports = {
-  valid: () => {
+  valid: (omissions) => {
     const user = generate(schema);
     user.password = bandname();
-    return user;
+    return _.omit(user, omissions);
   }
 };
 {{/isUser}}

--- a/model/index.js
+++ b/model/index.js
@@ -19,6 +19,7 @@ module.exports = (opts) => {
     { n: 'model', d: 'models', t: opts.snakeCase },
     { n: 'controller', d: 'controllers', t: opts.snakeCase },
     { n: 'test', d: 'test/models', t: `${opts.snakeCase}_test` },
+    { n: 'test/fixture', d: 'test/fixtures', t: `${opts.snakeCase}_test` },
     { n: 'route', d: 'routes', t: opts.snakeCase },
     { n: 'table', d: 'tables', t: opts.snakeCase },
     { n: 'fixture', d: 'fixtures', t: opts.snakeCase },

--- a/model/test/fixture.mustache
+++ b/model/test/fixture.mustache
@@ -1,0 +1,14 @@
+const fixture = require('fixtures/{{snakeCase}}');
+const schema = require('lib/schema');
+const validate = schema.getValidator('{{camelCase}}');
+
+describe('fixtures/{{camelCase}}', () => {
+  describe('valid', () => {
+    it('should return a valid model', () => {
+      validate(fixture.valid()).must.be.true();
+    });
+    it('should omit things if asked', () => {
+      fixture.valid(['name']).must.not.have.property('name');
+    });
+  });
+});


### PR DESCRIPTION
This allows you to easily omit fields from fixtures when creating them.

Open for discussion on whether this is an 80% feature or a 20% feature. It's something that Simon needed on a project, but it's also the kind of thing that's pretty trivial to do within your test suite. The question is whether the utility this provides the user is sufficient to eclipse the extra complexity it adds to the fixture code.