### PR TITLE
Use env vars rather than mutating db name within helper script

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -15,7 +15,6 @@ module.exports = (opts) => {
     { n: 'docker-compose', e: 'yml' },
     { n: 'dotenv', t: 'example.env', e: '' },
     { p: 'lib', n: 'db' },
-    { p: 'lib', n: 'db_helper' },
     { p: 'lib', n: 'migrate' },
     { p: 'lib', n: 'util' },
     { n: 'index' },

--- a/base/lib/db.mustache
+++ b/base/lib/db.mustache
@@ -1,8 +1,6 @@
-const db = require('lib/db_helper');
-
 const HOST = process.env.RETHINK_HOST;
 const PORT = process.env.RETHINK_PORT;
-const DB_NAME = db.getName();
+const DB_NAME = process.env.RETHINK_NAME;
 
 const r = require('rethinkdbdash')({ db: DB_NAME, servers: [{ host: HOST, port: PORT }] });
 

--- a/base/lib/db_helper.mustache
+++ b/base/lib/db_helper.mustache
@@ -1,4 +1,0 @@
-exports.getName = function getDbName() {
-  const suffix = process.env.NODE_ENV === 'test' ? '_test' : '';
-  return `${process.env.RETHINK_NAME}${suffix}`;
-};

--- a/base/package.mustache
+++ b/base/package.mustache
@@ -8,7 +8,7 @@
     "migrate": "node ./bin/migrate.js",
     "migration": "node ./bin/migration.js",
     "start": "node start",
-    "test": "mocha",
+    "test": "RETHINK_NAME={{snakeCasePlural}}_test mocha",
     "watch": "mocha --watch",
     "dockertest": "docker-compose run {{snakeCasePlural}} npm test",
     "dockerwatch": "docker-compose run {{snakeCasePlural}} npm run watch"

--- a/base/setup.mustache
+++ b/base/setup.mustache
@@ -1,9 +1,8 @@
-const db = require('lib/db_helper');
-
 const r = require('lib/db');
 const migrate = require('lib/migrate');
 const schema = require('schema');
-const DB_NAME = db.getName();
+
+const DB_NAME = process.env.RETHINK_NAME;
 
 const tables = require('./tables');
 

--- a/base/tables/migrations.mustache
+++ b/base/tables/migrations.mustache
@@ -1,7 +1,6 @@
 const r = require('lib/db.js');
-const db = require('lib/db_helper.js');
 
-const DB_NAME = db.getName();
+const DB_NAME = process.env.RETHINK_NAME;
 
 module.exports = () => {
   return r.tableCreate('_migrations', { primaryKey: 'name' }).run()

--- a/base/test/helper.mustache
+++ b/base/test/helper.mustache
@@ -7,8 +7,8 @@ require('app-module-path').addPath(path.resolve(__dirname, '..'));
 const setup = require('setup');
 const app = require('index');
 const r = require('lib/db');
-const db = require('lib/db_helper');
-const DB_NAME = db.getName();
+
+const DB_NAME = process.env.RETHINK_NAME;
 
 app.listen(process.env.PORT, () => {
   before(function before() {


### PR DESCRIPTION
This helper script actually broke the error handling code in the table creators.
Setting the env var is a much simpler way to achieve the desired outcome.