### PR TITLE
Upgrade lodash

### DIFF
--- a/model/lib/rethinkdb.mustache
+++ b/model/lib/rethinkdb.mustache
@@ -21,7 +21,7 @@ exports.addTransformations = (table, indexes, params) => {
     if (params[item]) {
       if (item === 'orderBy') {
         const order = params.order || 'asc';
-        const isIndexed = _.contains(indexes, 'orderBy');
+        const isIndexed = _.includes(indexes, 'orderBy');
         if (isIndexed) q = q[item]({ index: r[order](params[item]) });
         else q = q[item](r[order](params[item]));
       } else {

--- a/model/model.mustache
+++ b/model/model.mustache
@@ -23,7 +23,7 @@ module.exports = {
 
     const table = r.table('{{snakeCasePlural}}');
     const indexes = model.getIndexes(modelSchema, queryParams);
-    const indexBy = _.contains(indexes, 'id') ? 'id' : indexes[0];
+    const indexBy = _.includes(indexes, 'id') ? 'id' : indexes[0];
 
     const query = rethinkdb.buildQuery(table, indexBy, queryParams);
     const tranformedQuery = rethinkdb.addTransformations(query, indexes, params);
@@ -51,7 +51,7 @@ module.exports = {
     const changes = { includeInitial: true, includeStates: true };
     const table = r.table('{{snakeCasePlural}}');
     const indexes = model.getIndexes(modelSchema, queryParams);
-    const indexBy = _.contains(indexes, 'id') ? 'id' : indexes[0];
+    const indexBy = _.includes(indexes, 'id') ? 'id' : indexes[0];
 
     let query = rethinkdb.buildQuery(table, indexBy, queryParams);
     query = rethinkdb.addTransformations(query, indexes, params);
@@ -142,7 +142,7 @@ module.exports = {
     const table = r.table('{{snakeCasePlural}}');
     const params = { email };
     const indexes = model.getIndexes(modelSchema, params);
-    const indexBy = _.contains(indexes, 'email') ? 'email' : null;
+    const indexBy = _.includes(indexes, 'email') ? 'email' : null;
 
     const query = rethinkdb.buildQuery(table, indexBy, params);
 

--- a/model/test.mustache
+++ b/model/test.mustache
@@ -176,7 +176,7 @@ describe('<%camelCase%> model', () => {
         .then(results => {
           const reordered = _.clone(results).sort(asc);
 
-          _.pluck(reordered, 'id').must.eql(_.pluck(results, 'id'));
+          _.map(reordered, 'id').must.eql(_.map(results, 'id'));
         });
     });
 
@@ -187,7 +187,7 @@ describe('<%camelCase%> model', () => {
         .then(results => {
           const reordered = _.clone(results).sort(desc);
 
-          _.pluck(reordered, 'id').must.eql(_.pluck(results, 'id'));
+          _.map(reordered, 'id').must.eql(_.map(results, 'id'));
         });
     });
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dockerwatch": "docker-compose run redbeard npm run watch"
   },
   "dependencies": {
-    "lodash": "^3.10.1",
+    "lodash": "^4.13.1",
     "mkdirp": "^0.5.1",
     "mustache": "^2.2.0",
     "pluralize": "^1.2.1",


### PR DESCRIPTION
This branch upgrades `lodash` to v4.

I found myself reaching for methods that didn't exist with v3.  A quick scan revealed only two methods stopping progress of moving forward - `_.contains` and `_.pluck`.  Both now replaced.

v4 introduced a few breaking changes, and also added speed increases and a lot of existing method shorthand iteratees that are very useful and reduce the surface area and noise when composing.

v4 also dropped over 6 months ago, so we should catchup.