### PR TITLE
Fix deref placement

### DIFF
--- a/base/schema.mustache
+++ b/base/schema.mustache
@@ -28,11 +28,11 @@ const indexModel = (indexes, properties) => {
 };
 
 const transformSchema = (indexes, schema) => {
-  return _.mapValues(schema, (model) => {
+  return deref(_.mapValues(schema, (model) => {
     const modelIndexes = indexes[model.camelCasePlural];
     model.properties = indexModel(modelIndexes, model.properties);
-    return deref(model);
-  });
+    return model;
+  }));
 };
 
 exports.setIndexes = () => {


### PR DESCRIPTION
Deref only needs to be called once against the collated schemas. It then walks the tree and resolve all references.

Called deref against each individual schema would resolve external dependencies, but does nothing for internal dependencies (unless you get really complicated about teaching it about the filesystem)

This allows us to simply reference other schemas internally with:

{
  "thing": {
    "$ref": "#other_thing"
  }
}

Where the file layout is:

schemas/thing.json
schemas/other_thing.json