### PR TITLE
Schema tweaks

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -21,6 +21,7 @@ module.exports = (opts) => {
     { n: 'package', e: 'json' },
     { n: 'schema' },
     { p: 'schemas', n: 'index' },
+    { p: 'schemas', n: 'definitions', e: 'json' },
     { n: 'setup' },
     { n: 'start' },
     { p: 'routes', n: 'jwt' },

--- a/base/package.mustache
+++ b/base/package.mustache
@@ -35,7 +35,7 @@
     "mocha": "^2.4.5",
     "must": "^0.13.1",
     "istanbul": "^0.4.1",
-    "json-schema-faker": "^0.2.5",
+    "json-schema-faker": "^0.3.3",
     "jsonwebtoken": "^5.4.1",
     "mustache": "^2.2.0",
     "node-fetch": "^1.3.3",

--- a/base/schemas/definitions.mustache
+++ b/base/schemas/definitions.mustache
@@ -1,0 +1,7 @@
+{
+  "uuid": {
+    "type": "string",
+    "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+    "faker": "random.uuid"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "istanbul": "^0.4.1",
     "jsen": "^0.6.0",
     "json-schema-deref-sync": "^0.2.8",
-    "json-schema-faker": "^0.2.5",
+    "json-schema-faker": "^0.3.3",
     "jsonwebtoken": "^5.4.1",
     "mocha": "^2.4.5",
     "must": "^0.13.1",

--- a/resource/schema.mustache
+++ b/resource/schema.mustache
@@ -16,7 +16,7 @@
     <%#isUser%>
     },
     "email": {
-      "type": "string",
+      "type": "email",
       "faker": "internet.exampleEmail"
     },
     "password": {

--- a/resource/schema.mustache
+++ b/resource/schema.mustache
@@ -5,13 +5,10 @@
   "camelCasePlural": "<%camelCasePlural%>",
   "properties": {
     "id": {
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-      "faker": "random.uuid"
+      "$ref": "#/definitions/uuid"
     },
     "rev": {
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      "$ref": "#/definitions/uuid"
     },
     "name": {
       "type": "string",
@@ -29,16 +26,14 @@
     <%#singularRelationships%>
     },
     "<%camelCase%>": {
-      "type": "string",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      "$ref": "#/definitions/uuid"
     <%/singularRelationships%>
     <%#multiRelationships%>
     },
     "<%camelCasePlural%>": {
       "type": "array",
       "items": {
-        "type": "string",
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+        "$ref": "#/definitions/uuid"
       }
     <%/multiRelationships%>
     }


### PR DESCRIPTION
This adds a definitions file as a place to put schema fragments that are used frequently throughout the schemas.

Also provides a demonstration of the $ref pattern.

As a side bonus, types the email field properly and updates the faker lib to support it.