### PR TITLE
Dry model

### DIFF
--- a/resource/controller.mustache
+++ b/resource/controller.mustache
@@ -40,11 +40,6 @@ module.exports = {
     })
     .then(model.update);
   },
-  {{/isUser}}
-  delete: id => {
-    return model.delete(id);
-  },
-{{#isUser}}
   signin: (email, pass) => {
     return model.get({ email })
     .then((res) => {
@@ -67,8 +62,11 @@ module.exports = {
   signout: body => {
     return model.signout(body);
   },
-{{/isUser}}
+  {{/isUser}}
+  delete: id => {
+    return model.delete(id);
+  },
   watch: query => {
-    return model.watch(query);
+    return model.get(query, true);
   }
 };

--- a/resource/controller.mustache
+++ b/resource/controller.mustache
@@ -16,6 +16,9 @@ module.exports = {
   create: body => {
     return model.create(body);
   },
+  update: body => {
+    return model.update(body);
+  },
   {{/isUser}}
   {{#isUser}}
   create: body => {
@@ -26,10 +29,18 @@ module.exports = {
       return model.create(data);
     });
   },
-  {{/isUser}}
   update: body => {
-    return model.update(body);
+    const getHash = body.password ?
+      password.create(body.password, HASH_ROUNDS)
+      : Promise.resolve();
+
+    return getHash.then(pass => {
+      if (pass) body.password = pass;
+      return body;
+    })
+    .then(model.update);
   },
+  {{/isUser}}
   delete: id => {
     return model.delete(id);
   },

--- a/resource/controller.mustache
+++ b/resource/controller.mustache
@@ -1,3 +1,9 @@
+{{#isUser}}
+const httpError = require('standard-http-error');
+const password = require('simple-password');
+const _ = require('lodash');
+const jwt = require('../lib/jwt');
+{{/isUser}}
 const model = require('../models/{{snakeCase}}.js');
 
 module.exports = {
@@ -14,8 +20,24 @@ module.exports = {
     return model.delete(id);
   },
 {{#isUser}}
-  signin: (email, password) => {
-    return model.signin(email, password);
+  signin: (email, pass) => {
+    return model.get({ email })
+    .then((res) => {
+      const users = res.result;
+      if (users.length === 0) throw new httpError('UNAUTHORIZED');
+      const user = users[0];
+      return password.verify(pass, user.password)
+      .then(verified => {
+        if (verified) return jwt.sign({ id: user.id, role: user.role });
+        throw new httpError('UNAUTHORIZED');
+      })
+      .then(token => {
+        return {
+          found: true,
+          result: { token, user: _.omit(user, 'password') }
+        };
+      });
+    });
   },
   signout: body => {
     return model.signout(body);

--- a/resource/controller.mustache
+++ b/resource/controller.mustache
@@ -3,6 +3,8 @@ const httpError = require('standard-http-error');
 const password = require('simple-password');
 const _ = require('lodash');
 const jwt = require('../lib/jwt');
+const HASH_ROUNDS = parseInt(process.env.HASH_ROUNDS, 10);
+const errors = require('../constants/errors');
 {{/isUser}}
 const model = require('../models/{{snakeCase}}.js');
 
@@ -10,9 +12,21 @@ module.exports = {
   get: query => {
     return model.get(query);
   },
+  {{^isUser}}
   create: body => {
     return model.create(body);
   },
+  {{/isUser}}
+  {{#isUser}}
+  create: body => {
+    if (!body.password) return Promise.reject(new httpError(422, errors.NO_PASSWORD));
+    return password.create(body.password, HASH_ROUNDS)
+    .then(hash => {
+      const data = _.merge(body, { password: hash });
+      return model.create(data);
+    });
+  },
+  {{/isUser}}
   update: body => {
     return model.update(body);
   },

--- a/resource/lib/rethinkdb.mustache
+++ b/resource/lib/rethinkdb.mustache
@@ -123,3 +123,21 @@ exports.changeFeed = (query, tableName) => {
     query: query.changes(changes)
   };
 };
+
+exports.queryWithCount = (query, transformedQuery, params) => {
+  const taggedQueries = [
+    { tag: 'result', q: transformedQuery },
+    { tag: 'count', q: query.count() }
+  ].filter(x => params[x.tag]);
+
+  return Promise.all(taggedQueries.map(x => x.q.run()))
+  .then(results => {
+    return results.reduce((response, result, i) => {
+      const tag = taggedQueries[i].tag;
+      response[tag] = result;
+      if (tag === 'count' && result > 0) response.found = true;
+      if (tag === 'response' && result.length > 0) response.found = true;
+      return response;
+    }, { found: false });
+  });
+};

--- a/resource/lib/rethinkdb.mustache
+++ b/resource/lib/rethinkdb.mustache
@@ -136,7 +136,7 @@ exports.queryWithCount = (query, transformedQuery, params) => {
       const tag = taggedQueries[i].tag;
       response[tag] = result;
       if (tag === 'count' && result > 0) response.found = true;
-      if (tag === 'response' && result.length > 0) response.found = true;
+      if (tag === 'result' && result && result.length > 0) response.found = true;
       return response;
     }, { found: false });
   });

--- a/resource/lib/rethinkdb.mustache
+++ b/resource/lib/rethinkdb.mustache
@@ -124,7 +124,7 @@ exports.changeFeed = (query, tableName) => {
   };
 };
 
-exports.queryWithCount = (query, transformedQuery, params) => {
+exports.queryWithCount = (query, transformedQuery, params, warns) => {
   const taggedQueries = [
     { tag: 'result', q: transformedQuery },
     { tag: 'count', q: query.count() }
@@ -138,6 +138,6 @@ exports.queryWithCount = (query, transformedQuery, params) => {
       if (tag === 'count' && result > 0) response.found = true;
       if (tag === 'result' && result && result.length > 0) response.found = true;
       return response;
-    }, { found: false });
+    }, { found: false, warns });
   });
 };

--- a/resource/lib/rethinkdb.mustache
+++ b/resource/lib/rethinkdb.mustache
@@ -2,6 +2,9 @@ const _ = require('lodash');
 const r = require('./db');
 const httpError = require('standard-http-error');
 
+const model = require('./model');
+const schema = require('./schema');
+
 const limitRegexp = /\.limit\(([^\)]*)\)/m;
 const orderByRegexp = /\.orderBy\(([^\)]*)\)/m;
 const filterRegexp = /\.filter\(([^\)]*)\)/m;
@@ -32,17 +35,35 @@ exports.addTransformations = (table, indexes, params) => {
   }, table);
 };
 
-exports.buildQuery = (table, indexBy, params) => {
+exports.queryBuilder = (tableName, modelName, params, primaryIndex = 'id') => {
+  const appSchema = require('../schema').getSchema();
+  const modelSchema = appSchema[modelName];
+
+  params = _.assign({ result: true }, model.normaliseParams(params));
+  const queryParams = schema.filter(modelName, params);
+
+  const indexes = model.getIndexes(modelSchema, queryParams);
+  const indexBy = _.includes(indexes, primaryIndex) ? primaryIndex : indexes[0];
+
+  const query = exports.buildQuery(tableName, indexBy, queryParams);
+
+  return { query, indexes, params };
+};
+
+exports.buildQuery = (tableName, indexBy, queryParams) => {
+  let query = r.table(tableName);
+
   // if only id passed, run query using .get(x)
-  if (params.id && Object.keys(params).length === 1) return table.get(params.id);
+  if (queryParams.id && Object.keys(queryParams).length === 1) return query.get(queryParams.id);
 
   if (indexBy != null) {
-    table = table.getAll(params[indexBy], { index: indexBy });
-    delete params[indexBy];
+    query = query.getAll(queryParams[indexBy], { index: indexBy });
+    delete queryParams[indexBy];
   }
 
-  if (!_.isEmpty(params)) table = table.filter(params);
-  return table;
+  if (!_.isEmpty(queryParams)) query = query.filter(queryParams);
+
+  return query;
 };
 
 // refer changefeed limitations here:-

--- a/resource/lib/rethinkdb.mustache
+++ b/resource/lib/rethinkdb.mustache
@@ -1,9 +1,12 @@
 const _ = require('lodash');
 const r = require('./db');
 const httpError = require('standard-http-error');
+const bunyan = require('bunyan');
+const log = bunyan.createLogger({ name: '{{kebabCase}}', level: process.env.LOG_LEVEL });
 
 const model = require('./model');
 const schema = require('./schema');
+const warnings = require('../constants/warnings');
 
 const limitRegexp = /\.limit\(([^\)]*)\)/m;
 const orderByRegexp = /\.orderBy\(([^\)]*)\)/m;
@@ -101,5 +104,22 @@ exports.ifRevMatches = update => {
       update,
       r.error('rev does not match')
     );
+  };
+};
+
+exports.changeFeed = (query, tableName) => {
+  const warns = [];
+
+  if (!exports.isChangeFeedable(query)) {
+    warns.push(warnings.RESTRICTED_FEED);
+    log.warn(warnings.RESTRICTED_FEED);
+    query = r.table(tableName).getAll(r.args(query.getField('id').coerceTo('array')));
+  }
+
+  const changes = { includeInitial: true, includeStates: true };
+
+  return {
+    warns,
+    query: query.changes(changes)
   };
 };

--- a/resource/model.mustache
+++ b/resource/model.mustache
@@ -6,7 +6,6 @@ const schema = require('../lib/schema');
 {{#isUser}}
 const _ = require('lodash');
 const errors = require('../constants/errors');
-const jwt = require('../lib/jwt');
 const password = require('simple-password');
 const HASH_ROUNDS = parseInt(process.env.HASH_ROUNDS, 10);
 {{/isUser}}
@@ -107,29 +106,5 @@ module.exports = {
       return res;
     })
     .then(rethinkdb.firstChange);
-  {{#isUser}}
-  },
-  signin: (email, pass) => {
-    const params = { email };
-
-    const { query } = rethinkdb.queryBuilder('{{snakeCasePlural}}', '{{camelCase}}', params);
-
-    return query.run()
-    .then(users => {
-      if (users.length === 0) throw new httpError('UNAUTHORIZED');
-      const user = users[0];
-      return password.verify(pass, user.password)
-      .then(verified => {
-        if (verified) return jwt.sign({ id: user.id, role: user.role });
-        throw new httpError('UNAUTHORIZED');
-      })
-      .then(token => {
-        return {
-          found: true,
-          result: { token, user: _.omit(user, 'password') }
-        };
-      });
-    });
-  {{/isUser}}
   }
 };

--- a/resource/model.mustache
+++ b/resource/model.mustache
@@ -3,10 +3,6 @@ const uuid = require('uuid');
 const r = require('../lib/db');
 const rethinkdb = require('../lib/rethinkdb');
 const schema = require('../lib/schema');
-{{#isUser}}
-const password = require('simple-password');
-const HASH_ROUNDS = parseInt(process.env.HASH_ROUNDS, 10);
-{{/isUser}}
 
 const validate = schema.getValidator('{{camelCase}}');
 
@@ -38,7 +34,6 @@ module.exports = {
     return r.table('{{snakeCasePlural}}').insert({{camelCase}}, { returnChanges: true }).run()
     .then(rethinkdb.firstChange);
   },
-  {{^isUser}}
   update: ({{camelCase}}) => {
     if (!{{camelCase}}.rev) {
       return Promise.reject(new httpError('BAD_REQUEST', 'No rev provided'));
@@ -54,38 +49,6 @@ module.exports = {
     .then(rethinkdb.checkRevError)
     .then(rethinkdb.firstChange);
   },
-  {{/isUser}}
-  {{#isUser}}
-  update: ({{camelCase}}) => {
-    if (!{{camelCase}}.rev) {
-      return Promise.reject(new httpError('BAD_REQUEST', 'No rev provided'));
-    }
-    let getHash;
-    if ({{camelCase}}.password) getHash = password.create({{camelCase}}.password, HASH_ROUNDS);
-    else getHash = Promise.resolve();
-
-    return getHash.then(pass => {
-      if (pass) {{camelCase}}.password = pass;
-
-      return r.table('{{snakeCasePlural}}').get({{camelCase}}.id).run()
-      .then(current => {
-        const updated = Object.assign({}, current, {{camelCase}});
-        const valid = validate(updated);
-        if (!valid) throw new httpError('UNPROCESSABLE_ENTITY');
-
-        return r.table('{{snakeCasePlural}}')
-        .get({{camelCase}}.id)
-        .update(
-          rethinkdb.ifRevMatches({{camelCase}}),
-          { returnChanges: true }
-        )
-        .run()
-        .then(rethinkdb.checkRevError)
-        .then(rethinkdb.firstChange);
-      });
-    });
-  },
-  {{/isUser}}
   delete: (id) => {
     return r.table('{{snakeCasePlural}}').get(id).delete({ returnChanges: true }).run()
     .then(res => {

--- a/resource/model.mustache
+++ b/resource/model.mustache
@@ -7,25 +7,19 @@ const schema = require('../lib/schema');
 const validate = schema.getValidator('{{camelCase}}');
 
 module.exports = {
-  get: (initialParams) => {
-    const { query, indexes, params } = rethinkdb.queryBuilder('{{snakeCasePlural}}', '{{camelCase}}', initialParams);
-    const transformedQuery = rethinkdb.addTransformations(query, indexes, params);
-
-    return rethinkdb.queryWithCount(query, transformedQuery, params);
-  },
-
-  watch: (initialParams) => {
+  get: (initialParams, rt) => {
     const { query: initialQuery, indexes, params } = rethinkdb.queryBuilder('{{snakeCasePlural}}', '{{camelCase}}', initialParams);
     let query = initialQuery;
-
     query = rethinkdb.addTransformations(query, indexes, params);
 
-    const ret = rethinkdb.changeFeed(query, '{{snakeCasePlural}}');
+    let warns = [];
+    if (rt) {
+      const ret = rethinkdb.changeFeed(query, '{{snakeCasePlural}}');
+      warns = ret.warns;
+      query = ret.query;
+    }
 
-    return Promise.resolve({
-      warns: ret.warns,
-      query: ret.query.run()
-    });
+    return rethinkdb.queryWithCount(initialQuery, query, params, warns);
   },
   create: ({{camelCase}}) => {
     const valid = validate({{camelCase}});

--- a/resource/model.mustache
+++ b/resource/model.mustache
@@ -1,11 +1,8 @@
 const httpError = require('standard-http-error');
 const uuid = require('uuid');
-const bunyan = require('bunyan');
-const log = bunyan.createLogger({ name: '{{kebabCase}}', level: process.env.LOG_LEVEL });
 const r = require('../lib/db');
 const rethinkdb = require('../lib/rethinkdb');
 const schema = require('../lib/schema');
-const warnings = require('../constants/warnings');
 {{#isUser}}
 const _ = require('lodash');
 const errors = require('../constants/errors');
@@ -38,24 +35,16 @@ module.exports = {
     });
   },
   watch: (initialParams) => {
-    const warns = [];
-
     const { query: initialQuery, indexes, params } = rethinkdb.queryBuilder('{{snakeCasePlural}}', '{{camelCase}}', initialParams);
     let query = initialQuery;
 
     query = rethinkdb.addTransformations(query, indexes, params);
 
-    if (!rethinkdb.isChangeFeedable(query)) {
-      warns.push(warnings.RESTRICTED_FEED);
-      log.warn(warnings.RESTRICTED_FEED);
-      query = r.table('{{snakeCasePlural}}').getAll(r.args(query.getField('id').coerceTo('array')));
-    }
-
-    const changes = { includeInitial: true, includeStates: true };
+    const ret = rethinkdb.changeFeed(query, '{{snakeCasePlural}}');
 
     return Promise.resolve({
-      warns,
-      query: query.changes(changes).run()
+      warns: ret.warns,
+      query: ret.query.run()
     });
   },
   {{^isUser}}

--- a/resource/model.mustache
+++ b/resource/model.mustache
@@ -4,8 +4,6 @@ const r = require('../lib/db');
 const rethinkdb = require('../lib/rethinkdb');
 const schema = require('../lib/schema');
 {{#isUser}}
-const _ = require('lodash');
-const errors = require('../constants/errors');
 const password = require('simple-password');
 const HASH_ROUNDS = parseInt(process.env.HASH_ROUNDS, 10);
 {{/isUser}}
@@ -33,7 +31,6 @@ module.exports = {
       query: ret.query.run()
     });
   },
-  {{^isUser}}
   create: ({{camelCase}}) => {
     const valid = validate({{camelCase}});
     if (!valid) return Promise.reject(new httpError('UNPROCESSABLE_ENTITY'));
@@ -41,6 +38,7 @@ module.exports = {
     return r.table('{{snakeCasePlural}}').insert({{camelCase}}, { returnChanges: true }).run()
     .then(rethinkdb.firstChange);
   },
+  {{^isUser}}
   update: ({{camelCase}}) => {
     if (!{{camelCase}}.rev) {
       return Promise.reject(new httpError('BAD_REQUEST', 'No rev provided'));
@@ -58,18 +56,6 @@ module.exports = {
   },
   {{/isUser}}
   {{#isUser}}
-  create: ({{camelCase}}) => {
-    if (!{{camelCase}}.password) return Promise.reject(new httpError(422, errors.NO_PASSWORD));
-    return password.create({{camelCase}}.password, HASH_ROUNDS)
-    .then(hash => {
-      const data = _.merge({{camelCase}}, { password: hash });
-      const valid = validate({{camelCase}});
-      if (!valid) throw new httpError('UNPROCESSABLE_ENTITY');
-      {{camelCase}}.rev = uuid.v4();
-      return r.table('{{snakeCasePlural}}').insert(data, { returnChanges: true }).run()
-      .then(rethinkdb.firstChange);
-    });
-  },
   update: ({{camelCase}}) => {
     if (!{{camelCase}}.rev) {
       return Promise.reject(new httpError('BAD_REQUEST', 'No rev provided'));

--- a/resource/model.mustache
+++ b/resource/model.mustache
@@ -16,24 +16,11 @@ const validate = schema.getValidator('{{camelCase}}');
 module.exports = {
   get: (initialParams) => {
     const { query, indexes, params } = rethinkdb.queryBuilder('{{snakeCasePlural}}', '{{camelCase}}', initialParams);
-    const tranformedQuery = rethinkdb.addTransformations(query, indexes, params);
+    const transformedQuery = rethinkdb.addTransformations(query, indexes, params);
 
-    const taggedQueries = [
-      { tag: 'result', q: tranformedQuery },
-      { tag: 'count', q: query.count() }
-    ].filter(x => params[x.tag]);
-
-    return Promise.all(taggedQueries.map(x => x.q.run()))
-    .then(results => {
-      return results.reduce((response, result, i) => {
-        const tag = taggedQueries[i].tag;
-        response[tag] = result;
-        if (tag === 'count' && result > 0) response.found = true;
-        if (tag === 'response' && result.length > 0) response.found = true;
-        return response;
-      }, { found: false });
-    });
+    return rethinkdb.queryWithCount(query, transformedQuery, params);
   },
+
   watch: (initialParams) => {
     const { query: initialQuery, indexes, params } = rethinkdb.queryBuilder('{{snakeCasePlural}}', '{{camelCase}}', initialParams);
     let query = initialQuery;

--- a/resource/model.mustache
+++ b/resource/model.mustache
@@ -1,34 +1,24 @@
-const _ = require('lodash');
 const httpError = require('standard-http-error');
 const uuid = require('uuid');
 const bunyan = require('bunyan');
 const log = bunyan.createLogger({ name: '{{kebabCase}}', level: process.env.LOG_LEVEL });
 const r = require('../lib/db');
-const model = require('../lib/model');
 const rethinkdb = require('../lib/rethinkdb');
 const schema = require('../lib/schema');
 const warnings = require('../constants/warnings');
 {{#isUser}}
+const _ = require('lodash');
 const errors = require('../constants/errors');
 const jwt = require('../lib/jwt');
 const password = require('simple-password');
 const HASH_ROUNDS = parseInt(process.env.HASH_ROUNDS, 10);
 {{/isUser}}
 
-const appSchema = require('../schema').getSchema();
-const modelSchema = appSchema.{{camelCase}};
 const validate = schema.getValidator('{{camelCase}}');
 
 module.exports = {
-  get: (params) => {
-    params = _.assign({ result: true }, model.normaliseParams(params));
-    const queryParams = schema.filter('{{camelCase}}', params);
-
-    const table = r.table('{{snakeCasePlural}}');
-    const indexes = model.getIndexes(modelSchema, queryParams);
-    const indexBy = _.includes(indexes, 'id') ? 'id' : indexes[0];
-
-    const query = rethinkdb.buildQuery(table, indexBy, queryParams);
+  get: (initialParams) => {
+    const { query, indexes, params } = rethinkdb.queryBuilder('{{snakeCasePlural}}', '{{camelCase}}', initialParams);
     const tranformedQuery = rethinkdb.addTransformations(query, indexes, params);
 
     const taggedQueries = [
@@ -47,24 +37,21 @@ module.exports = {
       }, { found: false });
     });
   },
-  watch: (params) => {
+  watch: (initialParams) => {
     const warns = [];
-    params = model.normaliseParams(params);
-    const queryParams = schema.filter('{{camelCase}}', params);
 
-    const changes = { includeInitial: true, includeStates: true };
-    const table = r.table('{{snakeCasePlural}}');
-    const indexes = model.getIndexes(modelSchema, queryParams);
-    const indexBy = _.includes(indexes, 'id') ? 'id' : indexes[0];
+    const { query: initialQuery, indexes, params } = rethinkdb.queryBuilder('{{snakeCasePlural}}', '{{camelCase}}', initialParams);
+    let query = initialQuery;
 
-    let query = rethinkdb.buildQuery(table, indexBy, queryParams);
     query = rethinkdb.addTransformations(query, indexes, params);
 
     if (!rethinkdb.isChangeFeedable(query)) {
       warns.push(warnings.RESTRICTED_FEED);
       log.warn(warnings.RESTRICTED_FEED);
-      query = table.getAll(r.args(query.getField('id').coerceTo('array')));
+      query = r.table('{{snakeCasePlural}}').getAll(r.args(query.getField('id').coerceTo('array')));
     }
+
+    const changes = { includeInitial: true, includeStates: true };
 
     return Promise.resolve({
       warns,
@@ -147,12 +134,9 @@ module.exports = {
   {{#isUser}}
   },
   signin: (email, pass) => {
-    const table = r.table('{{snakeCasePlural}}');
     const params = { email };
-    const indexes = model.getIndexes(modelSchema, params);
-    const indexBy = _.includes(indexes, 'email') ? 'email' : null;
 
-    const query = rethinkdb.buildQuery(table, indexBy, params);
+    const { query } = rethinkdb.queryBuilder('{{snakeCasePlural}}', '{{camelCase}}', params);
 
     return query.run()
     .then(users => {

--- a/resource/route.mustache
+++ b/resource/route.mustache
@@ -26,15 +26,13 @@ module.exports = {
     const nsp = io.of('/{{kebabCasePlural}}');
     nsp.on('connection', socket => {
       controller.watch(socket.handshake.query)
-      .then(({ query, warns = [] }) => {
+      .then(({ result: cursor, warns = [] }) => {
         warns.forEach(warn => socket.emit('warning', warn));
 
-        query.then(cursor => {
-          cursor.each((err, data) => {
-            if (!data) return null;
-            if (data.state) return socket.emit('state', data);
-            return socket.emit('record', data);
-          });
+        cursor.each((err, data) => {
+          if (!data) return null;
+          if (data.state) return socket.emit('state', data);
+          return socket.emit('record', data);
         });
       });
     });

--- a/resource/test/lib/rethinkdb.mustache
+++ b/resource/test/lib/rethinkdb.mustache
@@ -6,7 +6,7 @@ describe('lib/rethinkdb', () => {
   describe('.buildQuery', () => {
     it('must return an unchanged query given no params', () => {
       const query = r.table('test');
-      const result = rethinkdb.buildQuery(query, null, {});
+      const result = rethinkdb.buildQuery('test', null, {});
 
       result.toString().must.equal(query.toString());
     });
@@ -14,7 +14,7 @@ describe('lib/rethinkdb', () => {
     it('must return a filered query given filters', () => {
       const query = r.table('test');
       const filters = { name: 'Darth Vader' };
-      const result = rethinkdb.buildQuery(query, null, filters);
+      const result = rethinkdb.buildQuery('test', null, filters);
       const expected = query.filter(filters);
 
       result.toString().must.equal(expected.toString());
@@ -23,7 +23,7 @@ describe('lib/rethinkdb', () => {
     it('must use an index when filters use an indexed property', () => {
       const query = r.table('test');
       const filters = { name: 'Darth Vader' };
-      const result = rethinkdb.buildQuery(query, 'name', filters);
+      const result = rethinkdb.buildQuery('test', 'name', filters);
       const expected = query.getAll('Darth Vader', { index: 'name' });
 
       result.toString().must.equal(expected.toString());
@@ -35,7 +35,7 @@ describe('lib/rethinkdb', () => {
         name: 'Darth Vader',
         sith: true
       };
-      const result = rethinkdb.buildQuery(query, 'name', filters);
+      const result = rethinkdb.buildQuery('test', 'name', filters);
       const expected = query.getAll('Darth Vader', { index: 'name' }).filter({ sith: true });
 
       result.toString().must.equal(expected.toString());
@@ -44,7 +44,7 @@ describe('lib/rethinkdb', () => {
     it('must use .get(x) when an id and no other params provided', () => {
       const query = r.table('test');
       const filters = { id: UUID };
-      const result = rethinkdb.buildQuery(query, null, filters);
+      const result = rethinkdb.buildQuery('test', null, filters);
       const expected = query.get(UUID);
 
       result.toString().must.equal(expected.toString());
@@ -53,7 +53,7 @@ describe('lib/rethinkdb', () => {
     it('must use .filter(x) when an id and other params provided', () => {
       const query = r.table('test');
       const filters = { id: UUID, name: 'Luke Skywalker' };
-      const result = rethinkdb.buildQuery(query, null, filters);
+      const result = rethinkdb.buildQuery('test', null, filters);
       const expected = query.filter(filters);
 
       result.toString().must.equal(expected.toString());


### PR DESCRIPTION
This PR pulls much more out of the model code and into the rethinkdb lib.

It also pulls all the conditional user logic out of the model and into the controller. This reflects the preferred pattern of maintaining a CRUD interface to the model and encapsulating business logic and additional methods in the controller.

The model _could_ be slimmed further, however I want to still leave seams in it. The most important one is in between the _where_ phase of the query returned from `queryBuilder` and the additions of limits and skips in the transform step. If a developer needs to mess with the query in a way that the params DSL doesn't allow them to, this gives them the agency to do it.