### PR TITLE
Allow counting records in sockets

### DIFF
--- a/resource/route.mustache
+++ b/resource/route.mustache
@@ -26,8 +26,10 @@ module.exports = {
     const nsp = io.of('/{{kebabCasePlural}}');
     nsp.on('connection', socket => {
       controller.watch(socket.handshake.query)
-      .then(({ result: cursor, warns = [] }) => {
+      .then(({ result: cursor, warns = [], count }) => {
         warns.forEach(warn => socket.emit('warning', warn));
+
+        if (count) socket.emit('metadata', { count });
 
         cursor.each((err, data) => {
           if (!data) return null;

--- a/resource/test.mustache
+++ b/resource/test.mustache
@@ -473,6 +473,22 @@ describe('<%camelCase%> model', () => {
         });
     });
 
+    it('accepts the same count param as GET requests', () => {
+      return <%camelCase%>Creator(2)
+        .then(() => {
+          return new Promise(resolve => {
+            const opts = { query: { count: true, limit: 1 }, forceNew: true };
+            const io = IO(`${url}/<%kebabCasePlural%>`, opts);
+            io.on('metadata', data => {
+              data.count.must.be.a.number();
+              data.count.must.be.gt(1);
+              io.disconnect();
+              resolve();
+            });
+          });
+        });
+    });
+
     it('emits a warning on an unchangefeedable query', () => {
       return <%camelCase%>Creator(2)
         .then(() => {


### PR DESCRIPTION
Sockets were previously missing the ability to pass the `count=true` query param in order to get a count of all matching docs.

This adds a `metadata` event to sockets, (alongside `data` and `state`) and sends the `count` property within it.

The potential danger in this is that at the time someone makes a query, the count of matching docs is 10. While the socket is open, someone POSTs 1000 new documents and now the count is hilariously wrong.

I think that's an edge case I don't care about. If the reviewer of this can think of a situation in which that kind of discrepancy would burn down an orphanage or something, then say so.