### PR TITLE
Catch setup errors

### DIFF
--- a/base/bin/migrate.mustache
+++ b/base/bin/migrate.mustache
@@ -1,5 +1,6 @@
-const migrate = require('lib/migrate');
+const migrate = require('../lib/migrate');
 const r = require('lib/db');
+const log = require('lib/logger');
 
 const commands = [
   'up',
@@ -11,7 +12,7 @@ const commands = [
 const command = process.argv[2];
 
 const barf = (msg) => {
-  console.log(msg);
+  log.error('migration error', msg);
   process.exit(1);
 };
 
@@ -32,13 +33,13 @@ if (command === 'release_mutex' && process.argv[3]) {
 }
 
 if (command === 'release_mutex') {
-  migrate.releaseMutex()
+  return migrate.releaseMutex()
   .then(() => r.getPoolMaster().drain())
   .then(() => process.exit());
 }
 
 if (command === 'show_mutex') {
-  migrate.queryMutex()
+  return migrate.queryMutex()
   .then(console.log)
   .then(() => r.getPoolMaster().drain())
   .then(() => process.exit());
@@ -48,4 +49,5 @@ migrate[command](process.argv[3])
 .then(() => {
   r.getPoolMaster().drain()
   .then(() => process.exit());
-});
+})
+.catch(barf);

--- a/base/lib/migrate.mustache
+++ b/base/lib/migrate.mustache
@@ -5,6 +5,7 @@ require('dotenv-safe').load({ sample: './example.env' });
 const os = require('os');
 const _ = require('lodash');
 const r = require('lib/db');
+const log = require('lib/logger');
 
 const table = r.table('_migrations');
 
@@ -60,7 +61,7 @@ module.exports = {
       }));
 
       return applyMigration(toBeApplied, (name) => {
-        console.log('migrated up', name);
+        log.info('migrated up', name);
         return table.insert({ name }).run();
       });
     })
@@ -81,7 +82,7 @@ module.exports = {
       }));
 
       return applyMigration(toBeDowned, (name) => {
-        console.log('migrated down', name);
+        log.info('migrated down', name);
         return table.get(name).delete().run();
       });
     })

--- a/base/lib/migrate.mustache
+++ b/base/lib/migrate.mustache
@@ -9,7 +9,7 @@ const log = require('lib/logger');
 
 const table = r.table('_migrations');
 
-const migrationFiles = require('migrations');
+const migrationFiles = require('migrations').filenames;
 
 const applyMigration = (migrations, then) => {
   if (migrations.length === 0) return Promise.resolve();

--- a/base/lib/util.mustache
+++ b/base/lib/util.mustache
@@ -16,7 +16,8 @@ module.exports = {
         const name = _.camelCase(path.parse(filename).name);
         r[name] = require(`${filepath}/${filename}`);
         return r;
-      }, {})
+      }, {}),
+      filenames: filtered
     };
   }
 };

--- a/base/start.mustache
+++ b/base/start.mustache
@@ -13,4 +13,9 @@ setup()
 
     log.info('{{camelCase}} API listening at http://%s:%s', host, port);
   });
+})
+.catch(e => {
+  console.log('Exiting due to error:');
+  console.log(e);
+  process.exit();
 });

--- a/base/start.mustache
+++ b/base/start.mustache
@@ -15,7 +15,6 @@ setup()
   });
 })
 .catch(e => {
-  console.log('Exiting due to error:');
-  console.log(e);
-  process.exit();
+  log.error('Setup error:', e);
+  process.exit(1);
 });


### PR DESCRIPTION
Currently if there are any DB or migration errors, the errors are logged (from their respective files) but the API keeps on humming, errors be damned.

This will catch any errors bubbled from database setup, or migrations, and log the error and quit.