### PR TITLE
Audit

### DIFF
--- a/migration/src/utils/migration.mustache
+++ b/migration/src/utils/migration.mustache
@@ -34,7 +34,6 @@ exports.create = name => {
   const now = new Date().toISOString();
   const migrationName = `${now}_${name}`;
   const root = path.resolve(__dirname, '../..');
-  const templates = `${root}/src/utils/templates`;
 
   const migrationFile = mustache.render(migrationFileTemplate, { migrationName });
   const migrationTest = mustache.render(migrationTestTemplate, { migrationName });

--- a/resource/src/utils/model.mustache
+++ b/resource/src/utils/model.mustache
@@ -19,25 +19,7 @@ exports.create = (modelName, opts = {}) => {
   model.standardQuery = exports.queryBuilder(model, modelSchema);
   model.standardFeed = exports.feedBuilder(model);
 
-  if (opts.audit) {
-    const auditModel = thinky.createModel(
-      modelSchema.pluralName + '_audit_log',
-      {
-        created_at: thinky.type.string(),
-        doc: thinky.type.object()
-      },
-      {}
-    );
-
-    model.post('save', function (next) {
-      new auditModel({
-        created_at: new Date().toISOString(),
-        doc: this
-      }).save(next);
-    });
-
-    model.auditModel = auditModel;
-  }
+  if (opts.audit) { exports.setupAuditLog(model); }
 
   return model;
 };
@@ -127,4 +109,29 @@ exports.feedBuilder = (Model) => (params = {}) => {
       });
     }
   }));
+};
+
+/**
+ * Sets up an audit log model that saves previous states of records
+ *
+ * @param {Class} model
+ * @return void
+ */
+exports.setupAuditLog = (model) => {
+  const AuditModel = thinky.createModel(
+    `${model.getTableName()}AuditLog`,
+    {
+      createdAt: Date,
+      doc: Object
+    }
+  );
+
+  model.post('save', function (next) {
+    new AuditModel({
+      createdAt: new Date(),
+      doc: Object.assign({}, this)
+    }).save(next);
+  });
+
+  model.AuditModel = AuditModel;
 };

--- a/resource/src/utils/model.mustache
+++ b/resource/src/utils/model.mustache
@@ -7,7 +7,7 @@ const { thinky, schema } = require('../../config');
  * @param {String} model name (in JSON schema)
  * @return {Class} thinky model
  */
-exports.create = (modelName) => {
+exports.create = (modelName, opts = {}) => {
   const modelSchema = schema[modelName];
   const validator = exports.thinkyValidatorFor(modelSchema);
   const model = thinky.createModel(
@@ -18,6 +18,26 @@ exports.create = (modelName) => {
 
   model.standardQuery = exports.queryBuilder(model, modelSchema);
   model.standardFeed = exports.feedBuilder(model);
+
+  if (opts.audit) {
+    const auditModel = thinky.createModel(
+      modelSchema.pluralName + '_audit_log',
+      {
+        created_at: thinky.type.string(),
+        doc: thinky.type.object()
+      },
+      {}
+    );
+
+    model.post('save', function (next) {
+      new auditModel({
+        created_at: new Date().toISOString(),
+        doc: this
+      }).save(next);
+    });
+
+    model.auditModel = auditModel;
+  }
 
   return model;
 };

--- a/resource/test/models/model_test.mustache
+++ b/resource/test/models/model_test.mustache
@@ -1,0 +1,1 @@
+const {{pascalCase}} = require('../../src/models/{{snakeCase}}');

--- a/resource/test/utils/model_test.mustache
+++ b/resource/test/utils/model_test.mustache
@@ -51,4 +51,46 @@ describe('utils/model', () => {
       );
     });
   });
+
+  describe('.create(modelName, {audit: true})', () => {
+    const TEST_JSON_SCHEMA = {
+      type: 'object',
+      name: 'auditableThing',
+      pluralName: 'auditableThings',
+      properties: {
+        id: {
+          type: 'string',
+          pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+        },
+        email: {
+          type: 'string',
+          format: 'email'
+        },
+        password: {
+          type: 'string'
+        }
+      },
+      required: [
+        'email',
+        'password'
+      ]
+    };
+    let Model;
+    const params = { email: 'blah@example.com', password: 'blah!' };
+
+    before(() => {
+      schema.auditableThing = TEST_JSON_SCHEMA;
+      Model = model.create('auditableThing', { audit: true });
+    });
+
+    it('should populate the audit log', function*() {
+      const thing = yield new Model(params).save();
+
+      const audit = yield Model.auditModel.filter({ doc: { id: thing.id } }).run();
+
+      audit[0].created_at.must.exist();
+      audit[0].doc.email.must.eql(params.email);
+      audit[0].doc.password.must.eql(params.password);
+    });
+  });
 });

--- a/resource/test/utils/model_test.mustache
+++ b/resource/test/utils/model_test.mustache
@@ -83,14 +83,13 @@ describe('utils/model', () => {
       Model = model.create('auditableThing', { audit: true });
     });
 
-    it('should populate the audit log', function*() {
-      const thing = yield new Model(params).save();
+    it('should populate the audit log', function * () {
+      const record = yield new Model(params).save();
 
-      const audit = yield Model.auditModel.filter({ doc: { id: thing.id } }).run();
+      const audit = yield Model.AuditModel.filter({ doc: { id: record.id } }).run();
 
-      audit[0].created_at.must.exist();
-      audit[0].doc.email.must.eql(params.email);
-      audit[0].doc.password.must.eql(params.password);
+      audit[0].createdAt.must.be.a(Date);
+      audit[0].doc.must.eql(Object.assign({}, record));
     });
   });
 });


### PR DESCRIPTION
Adds an optional automatic audit trail for models

If you pass the audit: true option to the model creator, this will create a secondary table for the model to which it saves a copy of a document every time its saved.