### PR TITLE
Change null to undefined on PATCH calls

### DIFF
--- a/resource/index.js
+++ b/resource/index.js
@@ -12,6 +12,7 @@ module.exports = (opts) => {
     { p: 'config', n: 'warnings' },
     { p: 'src/utils', n: 'model' },
     { p: 'src/utils', n: 'controller' },
+    { p: 'src/utils', n: 'helpers' },
     { p: 'test/utils', n: 'model_test' },
     { p: 'src/models', n: 'index' },
     { n: 'src/models/model', d: 'src/models', t: opts.snakeCase },

--- a/resource/src/routes/route.mustache
+++ b/resource/src/routes/route.mustache
@@ -1,4 +1,5 @@
 const { Router } = require('express');
+const { nullToUndefined } = require('../utils/helpers');
 const {{camelCasePlural}} = require('../controllers/{{snakeCasePlural}}');
 
 const serialize = ({{camelCase}}) => {
@@ -27,7 +28,8 @@ const router = module.exports = new Router()
     res.json(serialize({{camelCase}}));
   })
   .patch('/:id', function * (req, res) {
-    const {{camelCase}} = yield {{camelCasePlural}}.update(req.params.id, req.body);
+    const replaced = nullToUndefined(req.body);
+    const {{camelCase}} = yield {{camelCasePlural}}.update(req.params.id, replaced);
     res.json(serialize({{camelCase}}));
   })
   .delete('/:id', function * (req, res) {

--- a/resource/src/utils/helpers.mustache
+++ b/resource/src/utils/helpers.mustache
@@ -1,0 +1,13 @@
+exports.nullToUndefined = input => {
+  if (Array.isArray(input)) return input;
+  const obj = Object.assign(input);
+  Object.keys(obj).forEach(key => {
+    const value = obj[key];
+    if (value === null) {
+      obj[key] = undefined;
+    } else if (typeof value === 'object') {
+      obj[key] = exports.nullToUndefined(value);
+    }
+  });
+  return obj;
+};

--- a/resource/test/routes/route_test.mustache
+++ b/resource/test/routes/route_test.mustache
@@ -181,6 +181,35 @@ describe('/{{kebabCasePlural}} route', () => {
     });
   });
 
+  describe('PATCH /:id', () => {
+    let {{camelCase}}ExtraProp;
+    const propText = 'oh hi I am an extra prop';
+    beforeEach(function * () {
+      const data = {{camelCase}}Fixture.valid();
+      data.extraProp = propText;
+      data.foo = {};
+      data.foo.bar = propText;
+      {{camelCase}}ExtraProp = yield {{camelCasePlural}}.create(data);
+    });
+    it('interprets null as a delete', function * () {
+      // https://tools.ietf.org/html/rfc7396
+      const existing = yield app.get('/{{kebabCasePlural}}/' + {{camelCase}}ExtraProp.id);
+      existing.body.extraProp.must.eql(propText);
+      existing.body.foo.bar.must.eql(propText);
+      const data = { extraProp: null, foo: { bar: null } };
+      const response = yield app.patch('/{{kebabCasePlural}}/' + {{camelCase}}ExtraProp.id, data);
+      response.status.must.eql(200);
+
+      const expected = Object.assign({}, {{camelCase}}ExtraProp, data);{{#isUser}}
+      delete(expected.password);{{/isUser}}
+      delete(expected.extraProp);
+      delete(expected.foo.bar);
+
+      response.body.must.eql(expected);
+    });
+  });
+
+
   describe('DELETE /:id', () => {
     it('deletes a record if it exists', function * () {
       const response = yield app.delete('/{{kebabCasePlural}}/' + {{camelCase}}.id);


### PR DESCRIPTION
rfc7396 requires null to be treated as a deletion. Thinky treats undefined as a deletion. This makes the two of them play nice together.